### PR TITLE
Implement workflow persistence

### DIFF
--- a/paigeant/__init__.py
+++ b/paigeant/__init__.py
@@ -5,6 +5,7 @@ from .dispatch import WorkflowDispatcher
 from .execute import ActivityExecutor
 from .integration import PaigeantAgent
 from .transports import get_transport
+from .db import WorkflowDB
 
 __version__ = "0.1.0"
 __all__ = [
@@ -15,4 +16,5 @@ __all__ = [
     "WorkflowDispatcher",
     "get_transport",
     "PaigeantAgent",
+    "WorkflowDB",
 ]

--- a/paigeant/db/__init__.py
+++ b/paigeant/db/__init__.py
@@ -1,0 +1,9 @@
+from .models import WorkflowRun, StepExecution, WorkflowVariable
+from .workflow_db import WorkflowDB
+
+__all__ = [
+    "WorkflowRun",
+    "StepExecution",
+    "WorkflowVariable",
+    "WorkflowDB",
+]

--- a/paigeant/db/models.py
+++ b/paigeant/db/models.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID, uuid4
+
+from sqlmodel import SQLModel, Field
+from sqlalchemy import Column, JSON
+
+
+class WorkflowRun(SQLModel, table=True):
+    """Represents an instance of a workflow execution."""
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True)
+    status: str = Field(default="in_progress")
+    started_at: datetime = Field(default_factory=datetime.utcnow)
+    finished_at: Optional[datetime] = None
+    correlation_id: Optional[str] = None
+
+
+class StepExecution(SQLModel, table=True):
+    """Tracks execution details for a single workflow step."""
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True)
+    workflow_run_id: UUID = Field(foreign_key="workflowrun.id")
+    step_name: str
+    status: str = Field(default="pending")
+    attempt: int = 1
+    input_payload: dict = Field(sa_column=Column(JSON))
+    output_payload: Optional[dict] = Field(default=None, sa_column=Column(JSON))
+    error_message: Optional[str] = None
+    started_at: datetime = Field(default_factory=datetime.utcnow)
+    finished_at: Optional[datetime] = None
+    max_retries: int = 3
+
+
+class WorkflowVariable(SQLModel, table=True):
+    """Key-value store for workflow variables."""
+
+    workflow_run_id: UUID = Field(foreign_key="workflowrun.id", primary_key=True)
+    key: str = Field(primary_key=True)
+    value: dict = Field(sa_column=Column(JSON))

--- a/paigeant/db/workflow_db.py
+++ b/paigeant/db/workflow_db.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime
+from typing import AsyncIterator
+from uuid import UUID
+
+from sqlmodel import SQLModel
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+
+from .models import WorkflowRun, StepExecution, WorkflowVariable
+
+
+class WorkflowDB:
+    """Simple async database helper for workflow persistence."""
+
+    def __init__(self, database_url: str) -> None:
+        self.engine = create_async_engine(
+            database_url, echo=False, future=True, connect_args={"check_same_thread": False}
+        )
+
+    async def init_db(self) -> None:
+        async with self.engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+    @asynccontextmanager
+    async def session(self) -> AsyncIterator[AsyncSession]:
+        async with AsyncSession(self.engine) as session:
+            yield session
+
+    async def create_run(self, correlation_id: str) -> WorkflowRun:
+        run = WorkflowRun(correlation_id=correlation_id)
+        async with self.session() as session:
+            session.add(run)
+            await session.commit()
+            await session.refresh(run)
+        return run
+
+    async def record_step_start(
+        self, run_id: UUID, step: str, payload: dict
+    ) -> StepExecution:
+        step_row = StepExecution(
+            workflow_run_id=run_id,
+            step_name=step,
+            status="in_progress",
+            input_payload=payload,
+        )
+        async with self.session() as session:
+            session.add(step_row)
+            await session.commit()
+            await session.refresh(step_row)
+        return step_row
+
+    async def record_step_result(self, step_id: UUID, result: dict | str) -> None:
+        async with self.session() as session:
+            step = await session.get(StepExecution, step_id)
+            if step is None:
+                return
+            step.output_payload = result
+            step.status = "completed"
+            step.finished_at = datetime.utcnow()
+            await session.commit()
+
+    async def record_step_error(self, step_id: UUID, error: str) -> None:
+        async with self.session() as session:
+            step = await session.get(StepExecution, step_id)
+            if step is None:
+                return
+            step.status = "failed"
+            step.error_message = error
+            step.finished_at = datetime.utcnow()
+            await session.commit()
+
+    async def set_variable(self, run_id: UUID, key: str, value: dict) -> None:
+        var = WorkflowVariable(workflow_run_id=run_id, key=key, value=value)
+        async with self.session() as session:
+            await session.merge(var)
+            await session.commit()
+
+    async def get_variable(self, run_id: UUID, key: str) -> dict | None:
+        async with self.session() as session:
+            var = await session.get(WorkflowVariable, (run_id, key))
+            return var.value if var else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@ dependencies = [
     "httpx>=0.28.1",
     "pydantic>=2.11.7",
     "pydantic-ai>=0.4.7",
+    "sqlmodel>=0.0.16",
+    "aiosqlite>=0.19.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_workflow_db.py
+++ b/tests/test_workflow_db.py
@@ -22,3 +22,22 @@ async def test_workflow_db_lifecycle(tmp_path):
     await db.set_variable(run.id, "x", {"a": 1})
     value = await db.get_variable(run.id, "x")
     assert value == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_record_step_error(tmp_path):
+    db = WorkflowDB(f"sqlite+aiosqlite:///{tmp_path/'err.db'}")
+    await db.init_db()
+
+    run = await db.create_run("err")
+    step = await db.record_step_start(run.id, "oops", {})
+
+    await db.record_step_error(step.id, "boom")
+
+    async with db.session() as session:
+        from paigeant.db.models import StepExecution
+
+        row = await session.get(StepExecution, step.id)
+        assert row.status == "failed"
+        assert row.error_message == "boom"
+        assert row.finished_at is not None

--- a/tests/test_workflow_db.py
+++ b/tests/test_workflow_db.py
@@ -1,0 +1,24 @@
+import asyncio
+import pytest
+
+from paigeant.db import WorkflowDB
+
+@pytest.mark.asyncio
+async def test_workflow_db_lifecycle(tmp_path):
+    db_path = tmp_path / "test.db"
+    db = WorkflowDB(f"sqlite+aiosqlite:///{db_path}")
+    await db.init_db()
+
+    run = await db.create_run("abc")
+    assert run.correlation_id == "abc"
+
+    step = await db.record_step_start(run.id, "step1", {"foo": "bar"})
+    assert step.step_name == "step1"
+
+    await db.record_step_result(step.id, {"ok": True})
+    value = await db.get_variable(run.id, "missing")
+    assert value is None
+
+    await db.set_variable(run.id, "x", {"a": 1})
+    value = await db.get_variable(run.id, "x")
+    assert value == {"a": 1}


### PR DESCRIPTION
## Summary
- add SQLModel-based workflow persistence models
- implement `WorkflowDB` helper for async DB operations
- expose workflow DB from library
- add dependency on sqlmodel and aiosqlite
- test persistence lifecycle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887cce3d460832ea6d01e02b6d5253e