### PR TITLE
Implement retry semantics

### DIFF
--- a/paigeant/__init__.py
+++ b/paigeant/__init__.py
@@ -1,6 +1,7 @@
 """Paigeant: Durable workflow orchestration for AI agents."""
 
 from .contracts import ActivitySpec, PaigeantMessage, RoutingSlip
+from .models import StepExecution
 from .dispatch import WorkflowDispatcher
 from .execute import ActivityExecutor
 from .integration import PaigeantAgent
@@ -15,4 +16,5 @@ __all__ = [
     "WorkflowDispatcher",
     "get_transport",
     "PaigeantAgent",
+    "StepExecution",
 ]

--- a/paigeant/contracts.py
+++ b/paigeant/contracts.py
@@ -6,6 +6,14 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
+
+class ActivityFailed(Exception):
+    """Raised when an activity fails and may be retried."""
+
+    def __init__(self, message: str, retryable: bool = True) -> None:
+        super().__init__(message)
+        self.retryable = retryable
+
 from pydantic import BaseModel, Field
 
 
@@ -49,6 +57,7 @@ class PaigeantMessage(BaseModel):
 
     message_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     correlation_id: str
+    attempt: int = 1
     trace_id: Optional[str] = None
     timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     obo_token: Optional[str] = None
@@ -65,3 +74,10 @@ class PaigeantMessage(BaseModel):
     def from_json(cls, data: str) -> "PaigeantMessage":
         """Deserialize message from JSON."""
         return cls.model_validate_json(data)
+
+    def bump_attempt(self) -> "PaigeantMessage":
+        """Return a copy of this message with incremented attempt and new ID."""
+        new_msg = self.model_copy(deep=True)
+        new_msg.message_id = str(uuid.uuid4())
+        new_msg.attempt += 1
+        return new_msg

--- a/paigeant/execute.py
+++ b/paigeant/execute.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 
 from importlib import import_module
 from typing import Any
+from datetime import datetime
 
 from pydantic import BaseModel
 from pydantic_ai import Agent
 
 from paigeant.deps.deserializer import DependencyDeserializer
 
-from .contracts import ActivitySpec, PaigeantMessage
+from .contracts import ActivityFailed, ActivitySpec, PaigeantMessage
+from .models import StepExecution
 from .transports import BaseTransport
+from .utils.retry import schedule_retry
 
 
 class HttpKey(BaseModel):
@@ -27,6 +30,7 @@ class ActivityExecutor:
         self._transport = transport
         self._agent_name = agent_name
         self._agent_path = agent_path
+        self._steps: dict[tuple[str, str], StepExecution] = {}
 
     def extract_activity(self, message: PaigeantMessage) -> ActivitySpec:
         """Extract routing slip from the message."""
@@ -36,11 +40,11 @@ class ActivityExecutor:
         """Start listening for workflow messages on the given topic."""
         async for raw_message, message in self._transport.subscribe(self._agent_name):
             activity = self.extract_activity(message)
-            await self._handle_activity(activity)
+            await self._handle_activity(activity, message)
             # Acknowledge the message was processed
             await self._transport.ack(raw_message)
 
-    async def _handle_activity(self, activity: ActivitySpec) -> None:
+    async def _handle_activity(self, activity: ActivitySpec, message: PaigeantMessage) -> None:
         """Handle incoming workflow activity."""
         print(f"Received activity: {activity}")
         print(f"Agent path: {self._agent_path}, Agent name: {self._agent_name}")
@@ -61,5 +65,36 @@ class ActivityExecutor:
             except Exception as e:
                 print(f"❌ Failed to deserialize deps: {e}")
 
-        result = await agent.run(activity.prompt, deps=deps)
-        print(result)
+        key = (message.correlation_id, activity.agent_name)
+        step = self._steps.get(key)
+        if not step:
+            step = StepExecution(
+                step_name=activity.agent_name,
+                workflow_id=message.correlation_id,
+                inputs=message.payload,
+            )
+            self._steps[key] = step
+
+        step.last_attempt_ts = datetime.utcnow()
+
+        try:
+            result = await agent.run(activity.prompt, deps=deps)
+            step.status = "success"
+            step.outputs = result if isinstance(result, dict) else {"result": result}
+            message.routing_slip.mark_complete(activity)
+            if isinstance(result, dict):
+                message.payload.update(result)
+
+            next_step = message.routing_slip.next_step()
+            if next_step:
+                await self._transport.publish(next_step.agent_name, message)
+        except ActivityFailed as e:
+            step.retry_count += 1
+            step.last_error = str(e)
+            if not e.retryable or step.retry_count > step.retry_limit:
+                step.status = "failed"
+            else:
+                await schedule_retry(step.retry_count)
+                new_msg = message.bump_attempt()
+                await self._transport.publish(activity.agent_name, new_msg)
+        print(step)

--- a/paigeant/models.py
+++ b/paigeant/models.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class StepExecution(BaseModel):
+    """Minimal execution record used for retry handling."""
+
+    step_name: str
+    workflow_id: str
+    status: str = "pending"  # pending, success, failed
+    inputs: dict[str, Any] = Field(default_factory=dict)
+    outputs: Optional[dict[str, Any]] = None
+    retry_count: int = 0
+    retry_limit: int = 3
+    last_error: Optional[str] = None
+    last_attempt_ts: datetime = Field(default_factory=datetime.utcnow)

--- a/paigeant/utils/retry.py
+++ b/paigeant/utils/retry.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import asyncio
+import random
+
+
+def compute_backoff(attempt: int, base: float = 1.5, jitter: float = 0.5) -> float:
+    """Compute exponential backoff with jitter."""
+    delay = base ** attempt
+    return delay + random.uniform(0, jitter)
+
+
+async def schedule_retry(attempt: int) -> None:
+    """Sleep for computed backoff delay before retrying."""
+    delay = compute_backoff(attempt)
+    await asyncio.sleep(delay)

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -5,11 +5,13 @@ from pydantic import BaseModel
 
 from paigeant import ActivityExecutor, get_transport
 from paigeant.contracts import (
+    ActivityFailed,
     ActivitySpec,
     PaigeantMessage,
     RoutingSlip,
     SerializedDeps,
 )
+from paigeant.utils.retry import compute_backoff
 
 
 class MockDeps(BaseModel):
@@ -37,3 +39,58 @@ async def test_activity_extraction():
     extracted = executor.extract_activity(message)
     assert extracted.agent_name == "test_agent"
     assert extracted.prompt == "Test task"
+
+
+def test_message_bump_attempt():
+    msg = PaigeantMessage(correlation_id="cid", routing_slip=RoutingSlip())
+    bumped = msg.bump_attempt()
+    assert bumped.attempt == msg.attempt + 1
+    assert bumped.message_id != msg.message_id
+
+
+def test_compute_backoff_growth():
+    first = compute_backoff(1, base=2, jitter=0)
+    second = compute_backoff(2, base=2, jitter=0)
+    assert second > first
+
+
+@pytest.mark.asyncio
+async def test_retry_on_failure(monkeypatch):
+    transport = get_transport()
+
+    class DummyAgent:
+        def __init__(self):
+            self.calls = 0
+
+        async def run(self, prompt: str, deps=None):
+            self.calls += 1
+            if self.calls < 2:
+                raise ActivityFailed("boom", retryable=True)
+            return {"ok": True}
+
+    # create dummy module
+    import types, sys
+
+    module = types.ModuleType("test_module")
+    module.test_agent = DummyAgent()
+    sys.modules["test_module"] = module
+
+    executor = ActivityExecutor(transport, "test_agent", "test_module")
+
+    activity = ActivitySpec(agent_name="test_agent", prompt="do it")
+    msg = PaigeantMessage(correlation_id="cid", routing_slip=RoutingSlip(itinerary=[activity]), payload={})
+
+    async def fake_sleep(_):
+        pass
+
+    monkeypatch.setattr("paigeant.utils.retry.schedule_retry", fake_sleep)
+
+    await executor._handle_activity(activity, msg)
+    # one retry should be queued
+    assert transport._queues["test_agent"]
+    raw, retry_msg = transport._queues["test_agent"].popleft()
+    assert retry_msg.attempt == 2
+
+    await executor._handle_activity(activity, retry_msg)
+    step = executor._steps[("cid", "test_agent")]
+    assert step.status == "success"


### PR DESCRIPTION
## Summary
- define `ActivityFailed` exception and message attempt tracking
- store step execution info in-memory
- implement backoff-based retry scheduling
- update executor to retry failed activities
- test retry logic and helper utilities

## Testing
- `uv pip install --system -e .[test]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887cd119d40832e8d7f5dd7087bf411