### PR TITLE
Improve coverage for routing slip and payload

### DIFF
--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -66,3 +66,5 @@ async def test_forward_to_next_step():
 
     assert message.routing_slip.executed[0].agent_name == "test_agent"
     assert len(transport._queues["next_agent"]) == 1
+    # Result from agent execution should be stored on the message
+    assert message.payload["test_agent"] == "success (no tool calls)"

--- a/tests/test_routing_slip.py
+++ b/tests/test_routing_slip.py
@@ -42,3 +42,22 @@ async def test_empty_routing_slip():
     assert slip.next_step() is None
     assert len(slip.itinerary) == 0
     assert len(slip.executed) == 0
+
+
+@pytest.mark.asyncio
+async def test_routing_slip_completion_state():
+    """Ensure completion helpers reflect workflow progress."""
+    step1 = ActivitySpec(agent_name="agent1", prompt="A")
+    step2 = ActivitySpec(agent_name="agent2", prompt="B")
+    slip = RoutingSlip(itinerary=[step1, step2])
+
+    assert slip.current_activity == step1
+    assert not slip.is_finished()
+
+    slip.mark_complete(step1)
+    assert slip.current_activity == step2
+    assert not slip.is_finished()
+
+    slip.mark_complete(step2)
+    assert slip.current_activity is None
+    assert slip.is_finished()


### PR DESCRIPTION
## Summary
- check that ActivityExecutor stores agent output in message payload
- cover `RoutingSlip.is_finished` and `current_activity` helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d1905c0c832e99335e293c0e548c