### PR TITLE
Add Kafka transport option

### DIFF
--- a/paigeant/transports/__init__.py
+++ b/paigeant/transports/__init__.py
@@ -7,6 +7,11 @@ import os
 from .base import BaseTransport
 from .inmemory import InMemoryTransport
 
+try:
+    from .kafka import KafkaTransport
+except Exception:
+    KafkaTransport = None  # type: ignore
+
 
 def get_transport() -> BaseTransport:
     """Factory function to get the configured transport."""
@@ -22,8 +27,15 @@ def get_transport() -> BaseTransport:
             port=int(os.getenv("REDIS_PORT", "6379")),
             password=os.getenv("REDIS_PASSWORD"),
         )
+    elif backend == "kafka":
+        if KafkaTransport is None:
+            raise ImportError("aiokafka package is required for KafkaTransport")
+        return KafkaTransport(
+            brokers=os.getenv("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"),
+            group_id=os.getenv("KAFKA_GROUP_ID", "paigeant"),
+        )
     else:
         raise ValueError(f"Unsupported transport backend: {backend}")
 
 
-__all__ = ["BaseTransport", "InMemoryTransport", "get_transport"]
+__all__ = ["BaseTransport", "InMemoryTransport", "KafkaTransport", "get_transport"]

--- a/paigeant/transports/kafka.py
+++ b/paigeant/transports/kafka.py
@@ -1,0 +1,98 @@
+"""Kafka transport implementation using aiokafka."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncIterator, Iterable, Optional, Tuple
+
+try:
+    from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
+    from aiokafka.structs import TopicPartition
+except Exception:  # pragma: no cover - aiokafka not installed
+    AIOKafkaConsumer = None  # type: ignore
+    AIOKafkaProducer = None  # type: ignore
+    TopicPartition = None  # type: ignore
+
+from ..contracts import PaigeantMessage
+from .base import BaseTransport
+
+
+class KafkaTransport(BaseTransport[Any]):
+    """Kafka-based transport for distributed messaging."""
+
+    def __init__(
+        self,
+        brokers: Iterable[str] | str = "localhost:9092",
+        group_id: str = "paigeant",
+        dlq_topic: str = "paigeant.deadletter",
+    ) -> None:
+        if AIOKafkaProducer is None or AIOKafkaConsumer is None:
+            raise ImportError("aiokafka package is required for KafkaTransport")
+
+        self.brokers = list(brokers) if isinstance(brokers, Iterable) and not isinstance(brokers, str) else [brokers]  # type: ignore[arg-type]
+        self.group_id = group_id
+        self.dlq_topic = dlq_topic
+        self._producer: Optional[AIOKafkaProducer] = None
+        self._consumer: Optional[AIOKafkaConsumer] = None
+
+    async def connect(self) -> None:
+        self._producer = AIOKafkaProducer(bootstrap_servers=self.brokers)
+        self._consumer = AIOKafkaConsumer(
+            bootstrap_servers=self.brokers,
+            group_id=self.group_id,
+            enable_auto_commit=False,
+            auto_offset_reset="earliest",
+        )
+        await self._producer.start()
+        await self._consumer.start()
+
+    async def disconnect(self) -> None:
+        if self._consumer:
+            await self._consumer.stop()
+            self._consumer = None
+        if self._producer:
+            await self._producer.stop()
+            self._producer = None
+
+    async def publish(self, topic: str, message: PaigeantMessage) -> None:
+        if not self._producer:
+            raise RuntimeError("KafkaTransport not connected")
+        data = message.to_json().encode()
+        await self._producer.send_and_wait(topic, value=data)
+
+    async def subscribe(
+        self, topic: str, timeout: Optional[float] = None
+    ) -> AsyncIterator[Tuple[Any, PaigeantMessage]]:
+        if not self._consumer:
+            raise RuntimeError("KafkaTransport not connected")
+        self._consumer.subscribe([topic])
+        start_time = asyncio.get_event_loop().time() if timeout else None
+
+        while True:
+            if timeout and start_time is not None:
+                if asyncio.get_event_loop().time() - start_time >= timeout:
+                    break
+            msg = await self._consumer.getone()
+            try:
+                envelope = PaigeantMessage.from_json(msg.value.decode())
+            except Exception:
+                await self.nack(msg, requeue=False)
+                continue
+            yield msg, envelope
+
+    async def ack(self, raw_message: Any) -> None:
+        if not self._consumer:
+            raise RuntimeError("KafkaTransport not connected")
+        tp = TopicPartition(raw_message.topic, raw_message.partition)
+        await self._consumer.commit({tp: raw_message.offset + 1})
+
+    async def nack(self, raw_message: Any, requeue: bool = True) -> None:
+        if not self._consumer:
+            raise RuntimeError("KafkaTransport not connected")
+        if requeue:
+            tp = TopicPartition(raw_message.topic, raw_message.partition)
+            await self._consumer.seek(tp, raw_message.offset)
+        else:
+            if self._producer:
+                await self._producer.send_and_wait(self.dlq_topic, value=raw_message.value)
+            await self.ack(raw_message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "ipython>=9.4.0",
     "redis>=6.2.0",
     "rq>=2.4.1",
+    "aiokafka>=0.12.0",
 ]
 
 [dependency-groups]

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -5,6 +5,11 @@ import pytest
 from paigeant.contracts import ActivitySpec, PaigeantMessage, RoutingSlip
 from paigeant.transports.inmemory import InMemoryTransport
 
+try:
+    from paigeant.transports.kafka import KafkaTransport
+except Exception:  # pragma: no cover - aiokafka not installed
+    KafkaTransport = None
+
 
 @pytest.mark.asyncio
 async def test_inmemory_transport_basic():
@@ -52,3 +57,12 @@ async def test_redis_transport_import():
             pass
     except ImportError:
         pytest.fail("RedisTransport should be importable")
+
+
+@pytest.mark.asyncio
+async def test_kafka_transport_import():
+    """Kafka transport should be importable and instantiable."""
+    if KafkaTransport is None:
+        pytest.skip("aiokafka not installed")
+    transport = KafkaTransport(brokers="localhost:9092", group_id="test")
+    assert transport.group_id == "test"


### PR DESCRIPTION
## Summary
- add a KafkaTransport using aiokafka
- support selecting `kafka` via `get_transport`
- include aiokafka in optional dependencies
- test that the Kafka transport can be imported

## Testing
- `pytest -k 'not integration' -q`

------
https://chatgpt.com/codex/tasks/task_e_688cc48623c4832e9d11d29ad6ec47dd