### PR TITLE
Update examples and tests for new agent registration

### DIFF
--- a/guides/dynamic_multi_agent_example.py
+++ b/guides/dynamic_multi_agent_example.py
@@ -42,6 +42,8 @@ topic_extractor_agent = PaigeantAgent(
         "Return just the topic name (e.g., 'cats', 'programming', 'work'). "
         "If no specific topic is mentioned, return 'general'."
     ),
+    dispatcher=dispatcher,
+    name="topic_extractor_agent",
 )
 
 # Second dynamically added agent: Joke forwarder
@@ -50,6 +52,8 @@ joke_forwarder_agent = PaigeantAgent(
     deps_type=JokeWorkflowDeps,
     output_type=str,
     system_prompt=("Forward the jokes to the next agent. "),
+    dispatcher=dispatcher,
+    name="joke_forwarder_agent",
 )
 
 # Third agent: Joke generator
@@ -63,6 +67,8 @@ joke_generator_agent = PaigeantAgent(
         "Return a list of joke strings."
     ),
     can_edit_itinerary=True,
+    dispatcher=dispatcher,
+    name="joke_generator_agent",
 )
 
 
@@ -75,6 +81,8 @@ joke_selector_agent = PaigeantAgent(
         "Format it nicely with proper setup and punchline. "
         "Use the jokes from the previous generator agent."
     ),
+    dispatcher=dispatcher,
+    name="joke_selector_agent",
 )
 
 
@@ -90,22 +98,19 @@ async def run_three_agent_joke_workflow():
     deps = JokeWorkflowDeps(http_key=http_key, user_token="joke-session-token")
 
     # Register first activity: Topic extraction
-    dispatcher.add_activity(
-        agent="topic_extractor_agent",
+    topic_extractor_agent.add_to_runway(
         prompt="Extract joke topic from: 'Tell me a funny joke about programming!  Add a step to forward the jokes to the joke_forwarder_agent.'",
         deps=deps,
     )
 
     # Register second activity: Joke generation
-    dispatcher.add_activity(
-        agent="joke_generator_agent",
+    joke_generator_agent.add_to_runway(
         prompt="Generate 3 jokes based on a given topics.",
         deps=deps,
     )
 
     # Register third activity: Joke selection and formatting
-    dispatcher.add_activity(
-        agent="joke_selector_agent",
+    joke_selector_agent.add_to_runway(
         prompt="Select and format the best joke from the given list",
         deps=deps,
     )
@@ -114,7 +119,6 @@ async def run_three_agent_joke_workflow():
         agent=joke_forwarder_agent,
         prompt="do nothing",
         deps=deps,
-        agent_name="joke_forwarder_agent",
     )
 
     # Dispatch the workflow

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,20 +20,24 @@ Simple, focused tests for the paigeant workflow dispatch library.
 # Basic functionality test
 uv run python -c "
 import asyncio
-from paigeant import ActivitySpec, WorkflowDispatcher, get_transport
+from paigeant import PaigeantAgent, WorkflowDependencies, WorkflowDispatcher, get_transport
+
+class Deps(WorkflowDependencies):
+    pass
 
 async def test():
     transport = get_transport()
-    dispatcher = WorkflowDispatcher(transport)
-    activities = [ActivitySpec(name='validate'), ActivitySpec(name='process'), ActivitySpec(name='notify')]
-    correlation_id = await dispatcher.dispatch_workflow(activities)
+    dispatcher = WorkflowDispatcher()
+    agent = PaigeantAgent('model', dispatcher=dispatcher, name='validate', deps_type=Deps)
+    agent.add_to_runway(prompt='process task', deps=Deps())
+    correlation_id = await dispatcher.dispatch_workflow(transport)
     print(f'Test passed: {correlation_id}')
 
 asyncio.run(test())
 "
 
 # Run examples
-uv run python examples/simple_agent_guide.py
+uv run python guides/single_agent_example.py
 ```
 
 ## Test Structure

--- a/tests/test_core_dispatch.py
+++ b/tests/test_core_dispatch.py
@@ -1,10 +1,18 @@
 """Core workflow dispatch functionality tests."""
 
+import os
 import pytest
 from pydantic import BaseModel
 
-from paigeant import WorkflowDependencies, WorkflowDispatcher, get_transport
+from paigeant import (
+    PaigeantAgent,
+    WorkflowDependencies,
+    WorkflowDispatcher,
+    get_transport,
+)
 from paigeant.contracts import ActivitySpec, SerializedDeps
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "test")
 
 
 class MockDeps(WorkflowDependencies):
@@ -15,22 +23,28 @@ class MockDeps(WorkflowDependencies):
 async def test_activity_registration_and_dispatch():
     """Test registering activities and dispatching workflow."""
     transport = get_transport()
-    dispatcher = WorkflowDispatcher(transport)
+    dispatcher = WorkflowDispatcher()
+
+    test_agent = PaigeantAgent(
+        "anthropic:claude-3-5-sonnet-latest",
+        dispatcher=dispatcher,
+        name="test_agent",
+        deps_type=MockDeps,
+    )
 
     # Register an activity with dependencies
     deps = MockDeps(api_key="secret-key")
-    activity = dispatcher.add_activity(
-        agent="test_agent", prompt="Process test task", deps=deps
-    )
+    test_agent.add_to_runway(prompt="Process test task", deps=deps)
 
     # Verify activity was created correctly
+    activity = dispatcher._itinerary[0]
     assert activity.agent_name == "test_agent"
     assert activity.prompt == "Process test task"
     assert activity.deps is not None
     assert activity.deps.type == "MockDeps"
 
     # Dispatch workflow
-    correlation_id = await dispatcher.dispatch_workflow()
+    correlation_id = await dispatcher.dispatch_workflow(transport)
     assert correlation_id is not None
     assert len(correlation_id) > 0
 
@@ -68,15 +82,27 @@ async def test_message_serialization():
 async def test_dispatcher_topic():
     """WorkflowDispatcher publishes message with trace_id and correct topic."""
     transport = get_transport()
-    dispatcher = WorkflowDispatcher(transport)
+    dispatcher = WorkflowDispatcher()
 
     class Deps(WorkflowDependencies):
         token: str
 
-    dispatcher.add_activity(agent="agent1", prompt="p1", deps=Deps(token="x"))
-    dispatcher.add_activity(agent="agent2", prompt="p2", deps=None)
+    agent1 = PaigeantAgent(
+        "anthropic:claude-3-5-sonnet-latest",
+        dispatcher=dispatcher,
+        name="agent1",
+        deps_type=Deps,
+    )
+    agent2 = PaigeantAgent(
+        "anthropic:claude-3-5-sonnet-latest",
+        dispatcher=dispatcher,
+        name="agent2",
+    )
 
-    correlation_id = await dispatcher.dispatch_workflow({"foo": "bar"})
+    agent1.add_to_runway(prompt="p1", deps=Deps(token="x"))
+    agent2.add_to_runway(prompt="p2", deps=None)
+
+    correlation_id = await dispatcher.dispatch_workflow(transport, {"foo": "bar"})
 
     # First queue should contain the published message
     queue = transport._queues["agent1"]
@@ -89,13 +115,19 @@ async def test_dispatcher_topic():
 @pytest.mark.asyncio
 async def test_activity_serialization_in_registry():
     """Registered activities should store serialized deps."""
-    transport = get_transport()
-    dispatcher = WorkflowDispatcher(transport)
+    dispatcher = WorkflowDispatcher()
 
     class D(WorkflowDependencies):
         value: int
 
-    dispatcher.add_activity(agent="agentA", prompt="p", deps=D(value=3))
+    agentA = PaigeantAgent(
+        "anthropic:claude-3-5-sonnet-latest",
+        dispatcher=dispatcher,
+        name="agentA",
+        deps_type=D,
+    )
+
+    agentA.add_to_runway(prompt="p", deps=D(value=3))
 
     stored = dispatcher._itinerary[0]
     assert stored.deps.type == "D"

--- a/tests/test_edit_itinerary.py
+++ b/tests/test_edit_itinerary.py
@@ -1,8 +1,13 @@
 import pytest
 
+import os
+
 from paigeant.agent.wrapper import PaigeantAgent
 from paigeant.contracts import ActivitySpec, PaigeantMessage, RoutingSlip
 from paigeant.tools import _edit_itinerary
+from paigeant.dispatch import WorkflowDispatcher
+
+os.environ.setdefault("ANTHROPIC_API_KEY", "test")
 
 
 @pytest.mark.asyncio
@@ -18,7 +23,13 @@ async def test_insert_activities():
 
 @pytest.mark.asyncio
 async def test_paigeant_agent_wrapper():
-    wrapper = PaigeantAgent("test", can_edit_itinerary=True, max_added_steps=2)
+    dispatcher = WorkflowDispatcher()
+    wrapper = PaigeantAgent(
+        "anthropic:claude-3-5-sonnet-latest",
+        dispatcher=dispatcher,
+        can_edit_itinerary=True,
+        max_added_steps=2,
+    )
     assert wrapper.can_edit_itinerary is True
 
 


### PR DESCRIPTION
## Summary
- refactor single- and multi-agent guides to use `PaigeantAgent.add_to_runway` with shared `WorkflowDispatcher`
- align core dispatch, itinerary editing, and integration tests with new registration flow
- document updated test invocation in tests README

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e9c2d3ab8832ebb00018a0e60bd6c