### PR TITLE
docs: streamline conceptual docs and refresh guides

### DIFF
--- a/CONCEPTUAL_GUIDE.md
+++ b/CONCEPTUAL_GUIDE.md
@@ -1,302 +1,45 @@
 # Paigeant: Conceptual Guide
 
-*A practical guide to understanding durable workflow orchestration for AI agents*
+Paigeant provides durable workflow orchestration for AI agents. It converts fragile chains of direct calls into message-driven workflows that survive crashes and restarts.
 
-## The Big Picture: Why Paigeant Exists
+## Problem
+Synchronous agent calls like `Agent A -> Agent B -> Agent C` fail if any agent is unavailable.
 
-### The Problem We're Solving
+## Solution
+Paigeant moves workflow state into messages and delivers each step through a transport queue:
 
-Imagine you're building a customer onboarding system using AI agents. You might have:
-- An agent that validates customer data
-- An agent that creates accounts  
-- An agent that sets up payment methods
-- An agent that sends welcome emails
+`Agent A -> queue -> Agent B -> queue -> Agent C`
 
-The naive approach would be to chain these agents together with direct calls:
+If an agent crashes, the message stays in the queue until a worker handles it.
 
-```
-Agent A → Agent B → Agent C → Agent D
-```
+## Core Components
+- **Routing Slip** – ordered list of `ActivitySpec` items. Tracks executed steps.
+- **PaigeantMessage** – envelope containing routing slip, payload, and correlation metadata.
+- **Transport** – delivers messages. The library ships with in-memory and Redis implementations.
+- **WorkflowDispatcher** – builds a routing slip and publishes the initial message.
+- **ActivityExecutor** – worker that subscribes to a topic, runs the agent, and forwards the message.
+- **PaigeantAgent** – thin wrapper around `pydantic_ai.Agent` with optional itinerary editing and access to previous outputs.
 
-This creates a **distributed monolith** - if any agent crashes, the entire workflow fails catastrophically. Your customer gets stuck in limbo, and you have no way to recover gracefully.
+## Architectural Principles
+1. **Asynchronous communication** – every step is delivered over the transport.
+2. **Durable execution** – workflow state lives in the message; workers can crash without losing progress.
+3. **Composability** – activities are small Python functions or agents; additional steps can be inserted at runtime when `can_edit_itinerary` is enabled.
 
-### The Paigeant Solution
-
-Paigeant transforms this fragile chain into a resilient, message-driven workflow:
-
-```
-Agent A → Message Queue → Agent B → Message Queue → Agent C → Message Queue → Agent D
-```
-
-Each step is independent, durable, and recoverable. If Agent C crashes, the workflow simply waits until it comes back online, then continues exactly where it left off.
-
-## Core Concepts: The Building Blocks
-
-### 1. The Routing Slip Pattern
-
-Think of a routing slip like a travel itinerary that follows a package through the mail system. In Paigeant, each workflow message carries its own "itinerary" - a list of tasks that need to be completed:
+## Basic Usage
 
 ```python
-# Example routing slip for customer onboarding
-itinerary = [
-    "validate-customer-data",    # ← Next step
-    "create-customer-account",
-    "setup-payment-method", 
-    "send-welcome-email"
-]
+from paigeant import PaigeantAgent, WorkflowDispatcher, get_transport, ActivityExecutor, WorkflowDependencies
+
+dispatcher = WorkflowDispatcher()
+agent = PaigeantAgent("anthropic:claude-3-5", dispatcher=dispatcher, deps_type=WorkflowDependencies)
+agent.add_to_runway(prompt="do work", deps=WorkflowDependencies())
+
+transport = get_transport()          # inmemory or redis
+correlation_id = await dispatcher.dispatch_workflow(transport)
+
+executor = ActivityExecutor(transport, "agent", "module.path")
+await executor.start()
 ```
 
-As each step completes, it gets moved from the "to-do" list to the "completed" list. The message knows where it's been and where it's going next.
-
-### 2. Messages as Containers
-
-Every workflow is carried by a `PaigeantMessage` that contains:
-
-- **Routing Slip**: The workflow's itinerary
-- **Payload**: Data needed by the workflow (customer info, preferences, etc.)
-- **Security Context**: Who initiated this workflow and what they're allowed to do
-- **Tracking Information**: Unique IDs for monitoring and debugging
-
-Think of it like a FedEx package with a detailed shipping label, contents, sender verification, and tracking number.
-
-### 3. Transport Abstraction
-
-Paigeant doesn't care how messages get delivered - it works with any message broker:
-
-- **In-Memory**: For development and testing
-- **RabbitMQ**: For production with high reliability
-- **Redis Streams**: For simpler deployments
-
-You can switch between them without changing your workflow logic.
-
-## The Three Architectural Principles
-
-### 1. Asynchronous-First Communication
-
-**Traditional approach (fragile):**
-```python
-# This blocks and can fail catastrophically
-result1 = agent_a.process(data)
-result2 = agent_b.process(result1)  # ← Crashes if agent_b is down
-result3 = agent_c.process(result2)  # ← Never executes
-```
-
-**Paigeant approach (resilient):**
-```python
-# This sends a message and continues
-await dispatcher.dispatch_workflow([
-    "process-with-agent-a",
-    "process-with-agent-b", 
-    "process-with-agent-c"
-])
-# Each step waits for the previous one, but failures don't cascade
-```
-
-### 2. Durable Execution
-
-Your workflow survives crashes because the state lives in the message, not in memory:
-
-- **Server crashes**: Workflow resumes on another server
-- **Network failures**: Messages wait in the queue
-- **Deployments**: Zero downtime for running workflows
-
-### 3. Security by Design
-
-Each message carries proof of:
-- **Who started it**: OAuth tokens for user identity
-- **What they can do**: Permission delegation
-- **Message integrity**: Cryptographic signatures prevent tampering
-
-## How You Use Paigeant
-
-### Step 1: Define Your Workflow
-
-Think about your business process as a series of independent steps:
-
-```python
-from paigeant import ActivitySpec
-
-# Define what needs to happen
-onboarding_steps = [
-    ActivitySpec(name="validate-customer-data"),
-    ActivitySpec(name="create-customer-account"),
-    ActivitySpec(name="setup-payment-method"),
-    ActivitySpec(name="send-welcome-email"),
-]
-```
-
-### Step 2: Dispatch the Workflow
-
-Send it into the system with the data it needs:
-
-```python
-from paigeant import WorkflowDispatcher, get_transport
-
-transport = get_transport()
-dispatcher = WorkflowDispatcher(transport)
-
-correlation_id = await dispatcher.dispatch_workflow(
-    activities=onboarding_steps,
-    variables={
-        "customer_email": "new.customer@example.com",
-        "subscription_tier": "premium"
-    }
-)
-```
-
-### Step 3: Build Workers to Handle Each Step
-
-Each activity gets handled by a dedicated service:
-
-```python
-# This service handles "validate-customer-data" messages
-async def handle_validation(message):
-    customer_email = message.payload["customer_email"]
-    
-    # Use your existing agents/logic here
-    is_valid = await customer_validator_agent.validate(customer_email)
-    
-    if is_valid:
-        # Mark this step complete and continue
-        message.routing_slip.mark_complete("validate-customer-data")
-        await transport.publish("workflows", message)
-    else:
-        # Handle validation failure
-        await handle_validation_error(message)
-```
-
-## Integration with AI Agents
-
-### Using Paigeant with pydantic-ai
-
-Paigeant includes built-in integration for pydantic-ai agents:
-
-```python
-from paigeant import create_planner_agent, PlannerAgentDeps
-
-# Create an AI agent that can dispatch workflows
-agent = create_planner_agent(model="openai:gpt-4")
-
-# Give it the ability to create workflows
-deps = PlannerAgentDeps(
-    workflow_dispatcher=dispatcher,
-    user_obo_token="user-session-token"
-)
-
-# Now your agent can create workflows based on natural language
-result = await agent.run(
-    "I need to onboard a new premium customer. Their email is john@example.com",
-    deps=deps
-)
-```
-
-The AI agent will automatically:
-1. Understand the request
-2. Call the `dispatch_workflow` tool
-3. Create appropriate activities
-4. Return a tracking ID
-
-### Workflow Workers Can Use Agents Too
-
-Each step in your workflow can be powered by sophisticated AI:
-
-```python
-# A workflow step that uses pydantic-ai internally
-async def handle_customer_support_ticket(message):
-    ticket_data = message.payload
-    
-    # Use an AI agent to analyze and route the ticket
-    support_agent = Agent(model="openai:gpt-4")
-    
-    analysis = await support_agent.run(
-        f"Analyze this support ticket and determine priority: {ticket_data}"
-    )
-    
-    # Update the workflow with the analysis
-    message.payload["analysis"] = analysis.data
-    message.routing_slip.mark_complete("analyze-ticket")
-    
-    await transport.publish("workflows", message)
-```
-
-## Real-World Scenarios
-
-### E-commerce Order Processing
-
-```python
-order_workflow = [
-    ActivitySpec(name="validate-order-details"),
-    ActivitySpec(name="check-inventory"),
-    ActivitySpec(name="process-payment"),
-    ActivitySpec(name="update-inventory"),
-    ActivitySpec(name="generate-shipping-label"),
-    ActivitySpec(name="send-confirmation-email"),
-    ActivitySpec(name="notify-warehouse")
-]
-```
-
-If payment processing fails, the workflow can:
-- Retry with backup payment methods
-- Hold inventory while customer updates payment info
-- Resume from the exact point of failure
-
-### Customer Support Automation
-
-```python
-support_workflow = [
-    ActivitySpec(name="classify-ticket-priority"),
-    ActivitySpec(name="route-to-specialist-team"),
-    ActivitySpec(name="research-customer-history"),
-    ActivitySpec(name="generate-initial-response"),
-    ActivitySpec(name="schedule-human-follow-up")
-]
-```
-
-Each step can use AI agents specialized for that task, creating a sophisticated but resilient support pipeline.
-
-## Key Benefits for Developers
-
-### 1. **Gradual Adoption**
-- Start with simple workflows
-- Add complexity as needed
-- Integrate with existing systems
-
-### 2. **Technology Flexibility**
-- Use any message broker
-- Mix different AI frameworks
-- Deploy on any infrastructure
-
-### 3. **Operational Excellence**
-- Built-in monitoring via correlation IDs
-- Graceful error handling and recovery
-- Zero-downtime deployments
-
-### 4. **Security First**
-- User permissions flow through the entire workflow
-- Messages are tamper-proof
-- Audit trails are automatic
-
-## When to Use Paigeant
-
-**Use Paigeant when:**
-- Your workflow spans multiple services
-- Steps take significant time (minutes to hours)
-- Failure recovery is critical
-- You need to track complex business processes
-- Multiple teams own different parts of the workflow
-
-**Don't use Paigeant when:**
-- Everything runs in a single process
-- You need millisecond response times
-- The workflow is simple and unlikely to fail
-- You're just starting with AI agents (start simple first)
-
-## Getting Started
-
-1. **Think in workflows**: Break your business process into independent steps
-2. **Start small**: Begin with 2-3 steps to understand the pattern
-3. **Add durability gradually**: Start with in-memory transport, upgrade to production brokers
-4. **Monitor and observe**: Use correlation IDs to track workflow progress
-5. **Scale up**: Add more complex workflows as your confidence grows
-
-Paigeant transforms the complexity of distributed AI systems into manageable, resilient building blocks. It's not magic - it's proven architectural patterns applied to the unique challenges of AI agent orchestration.
+## When to Use
+Paigeant is useful when workflows span multiple services or may run for minutes or hours. It is unnecessary for single-process, low-latency tasks.

--- a/README.md
+++ b/README.md
@@ -1,377 +1,55 @@
 # Paigeant
 
-**Durable workflow orchestration for AI agents in distributed systems**
+Durable workflow orchestration for AI agents.
 
-*Transform fragile agent call chains into resilient, production-ready workflows*
+Paigeant lets independent `pydantic-ai` agents coordinate through a message queue. Each workflow step is delivered as a message that carries its own routing slip and payload, allowing execution to resume after crashes or deployments.
 
----
-
-## What is Paigeant?
-
-Paigeant is a Python library that provides the messaging infrastructure to orchestrate AI agents across distributed services. It solves the fundamental problem of building resilient, multi-agent workflows that can survive crashes, network failures, and deployments without losing work or state.
-
-**The Problem**: Chaining AI agents together with direct calls creates a "distributed monolith" - if any agent crashes, the entire workflow fails catastrophically.
-
-**The Solution**: Paigeant transforms fragile call chains into durable, message-driven workflows where each step is independent, recoverable, and can resume exactly where it left off.
-
-```
-Fragile: Agent A → Agent B → Agent C → Agent D (crashes cascade)
-Fragile: Agent A calls Agent B, which calls Agent C, which calls Agent D
-
-Resilient: Agent A → Queue → Agent B → Queue → Agent C → Queue → Agent D
-```
-
-## Core Principles
-
-Paigeant is built on three foundational architectural principles:
-
-1. **Asynchronous-First Communication** - All inter-agent communication is async by default, eliminating blocking calls and cascade failures
-2. **💾 Durable Execution** - Workflows survive crashes because state lives in messages, not memory
-3. **🔒 Zero-Trust Messaging** - Built-in security with OAuth delegation and cryptographic message integrity
-
-## What You Can Build
-
-### Real-World Use Cases
-
-**Customer Onboarding Pipeline**
-```python
-onboarding_workflow = [
-    "validate-customer-data",
-    "create-customer-account", 
-    "setup-payment-method",
-    "send-welcome-email"
-]
-```
-If payment processing fails, the workflow holds state and retries with backup methods - no lost progress.
-
-**E-commerce Order Processing**
-```python
-order_workflow = [
-    "validate-order",
-    "check-inventory", 
-    "process-payment",
-    "update-inventory",
-    "generate-shipping-label",
-    "send-confirmation"
-]
-```
-Each step can be handled by specialized AI agents, with automatic retry and recovery.
-
-**Support Ticket Automation**
-```python
-support_workflow = [
-    "classify-ticket-priority",
-    "route-to-specialist",
-    "research-customer-history", 
-    "generate-response",
-    "schedule-follow-up"
-]
-```
-Sophisticated AI analysis at each step, with human handoff capabilities.
-
-## Key Features
-
-- **Asynchronous messaging** - Non-blocking, resilient inter-agent communication
-- **Durable execution** - Workflows survive crashes, restarts, and deployments  
-- **Pluggable transports** - In-memory, RabbitMQ, Redis Streams support
-- **Routing slip pattern** - Workflow logic travels with the message
-- **Security-ready** - OAuth tokens and message signing built-in
-- **Observable** - Correlation IDs for monitoring and debugging
-- **AI-native** - Built-in pydantic-ai integration
+## Features
+- Asynchronous, message-driven workflows
+- Routing slip model with previous-output injection
+- Optional itinerary editing: agents can insert additional steps
+- Transport abstraction with in-memory and Redis backends
+- Minimal dependencies and `pydantic-ai` integration
 
 ## Quick Start
 
-### 1. Install Paigeant
-
 ```bash
 uv add paigeant
 ```
 
-### 2. Define Your Workflow
-
-Think of your business process as independent steps:
+Define and dispatch a workflow:
 
 ```python
-from paigeant import ActivitySpec
+from paigeant import PaigeantAgent, WorkflowDispatcher, get_transport, WorkflowDependencies
 
-onboarding_steps = [
-    ActivitySpec(name="validate-customer-data"),
-    ActivitySpec(name="create-customer-account"),
-    ActivitySpec(name="setup-payment-method"),
-    ActivitySpec(name="send-welcome-email"),
-]
+dispatcher = WorkflowDispatcher()
+agent = PaigeantAgent("anthropic:claude-3-5", dispatcher=dispatcher, deps_type=WorkflowDependencies)
+agent.add_to_runway(prompt="do work", deps=WorkflowDependencies())
+
+transport = get_transport()          # inmemory by default or PAIGEANT_TRANSPORT=redis
+correlation_id = await dispatcher.dispatch_workflow(transport)
 ```
 
-### 3. Dispatch the Workflow
+Run a worker:
 
 ```python
-import asyncio
-from paigeant import WorkflowDispatcher, get_transport
+from paigeant import ActivityExecutor
 
-async def main():
-    transport = get_transport()
-    await transport.connect()
-    
-    dispatcher = WorkflowDispatcher(transport)
-    
-    correlation_id = await dispatcher.dispatch_workflow(
-        activities=onboarding_steps,
-        variables={
-            "customer_email": "new.customer@example.com",
-            "subscription_tier": "premium"
-        }
-    )
-    
-    print(f"Workflow dispatched: {correlation_id}")
-    await transport.disconnect()
-
-asyncio.run(main())
+executor = ActivityExecutor(transport, "agent", "my.module")
+await executor.start()
 ```
 
-### 4. Build Workers for Each Step
+## Transports
+The library currently supports in-memory queues for testing and Redis lists for cross-process messaging. Other brokers can be added by implementing `BaseTransport`.
 
-Each activity gets handled by a dedicated service:
-
-```python
-# Worker service handling "validate-customer-data" messages
-async def handle_validation(message):
-    customer_email = message.payload["customer_email"]
-    
-    # Use your existing agents/logic here
-    is_valid = await customer_validator_agent.validate(customer_email)
-    
-    if is_valid:
-        # Mark complete and continue workflow
-        message.routing_slip.mark_complete("validate-customer-data")
-        await transport.publish("workflows", message)
-    else:
-        # Handle validation failure with custom logic
-        await handle_validation_error(message)
-```
-
-## AI Agent Integration
-
-### With pydantic-ai
-
-Paigeant includes built-in integration for pydantic-ai agents:
-
-```python
-from paigeant import create_planner_agent, PlannerAgentDeps
-
-# Create an AI agent that can dispatch workflows
-agent = create_planner_agent(model="openai:gpt-4")
-
-# Give it workflow dispatch capabilities
-deps = PlannerAgentDeps(
-    workflow_dispatcher=dispatcher,
-    user_obo_token="user-session-token"
-)
-
-# Agent creates workflows from natural language
-result = await agent.run(
-    "I need to onboard a new premium customer: john@example.com",
-    deps=deps
-)
-```
-
-The AI agent automatically:
-1. Understands the request
-2. Creates appropriate workflow activities  
-3. Dispatches the workflow
-4. Returns a tracking ID
-
-### Agents as Workflow Steps
-
-Each workflow step can use sophisticated AI internally:
-
-```python
-async def handle_support_ticket(message):
-    ticket_data = message.payload
-    
-    # Use AI agent for analysis
-    support_agent = Agent(model="openai:gpt-4")
-    analysis = await support_agent.run(
-        f"Analyze this support ticket: {ticket_data}"
-    )
-    
-    # Continue workflow with analysis
-    message.payload["analysis"] = analysis.data
-    message.routing_slip.mark_complete("analyze-ticket")
-    await transport.publish("workflows", message)
-```
-
-## How It Works: Technical Architecture
-
-### The Routing Slip Pattern
-
-Every workflow message carries its own "itinerary" - a routing slip that tracks:
-
-- **Activities to complete**: The workflow's task list
-- **Completed activities**: What's been done
-- **Payload data**: Information flowing through the workflow
-- **Security context**: User permissions and message integrity
-
-```python
-# Example message structure
-{
-    "correlation_id": "uuid-here",
-    "routing_slip": {
-        "itinerary": ["validate", "create", "notify"],
-        "completed": ["validate"],
-        "current": "create"
-    },
-    "payload": {
-        "customer_email": "user@example.com",
-        "subscription_tier": "premium"
-    },
-    "security": {
-        "obo_token": "oauth-token",
-        "jws_signature": "cryptographic-signature"
-    }
-}
-```
-
-### Federated Architecture
-
-Paigeant follows a clean separation of concerns:
-
-- **Task Layer** (pydantic-ai): In-process agent execution and reasoning
-- **Workflow Layer** (paigeant): Cross-service message orchestration
-
-This federated approach means:
-- No centralized orchestrator (eliminating single points of failure)
-- Each service owns its business logic
-- Workflow state travels with the message
-- Easy to scale and deploy independently
-
-### Transport Abstraction
-
-Paigeant works with any message broker:
-
-```python
-# Development
-export PAIGEANT_TRANSPORT=inmemory
-
-# Production options  
-export PAIGEANT_TRANSPORT=rabbitmq
-export PAIGEANT_TRANSPORT=redis
-```
-
-You can switch transports without changing workflow code, enabling:
-- **Local development** with in-memory queues
-- **Production deployment** with enterprise message brokers
-- **Hybrid architectures** mixing different transports
-
-## Key Benefits
-
-### For Developers
-- **Gradual adoption** - Start simple, add complexity as needed
-- **Technology flexibility** - Mix different AI frameworks and infrastructure  
-- **Built-in observability** - Correlation IDs for monitoring and debugging
-- **Security first** - User permissions flow through entire workflows
-
-### For Operations
-- **Fault tolerance** - Graceful error handling and recovery
-- **Zero-downtime deployments** - Running workflows survive updates
-- **Horizontal scaling** - Add workers without workflow changes
-- **Audit trails** - Complete workflow history and state tracking
-
-### For Business
-- **Process reliability** - Critical workflows never lose progress
-- **Automatic recovery** - Temporary failures don't break business processes  
-- **Workflow visibility** - Track complex processes end-to-end
-- **Faster iterations** - Independent services deploy and scale separately
-
-## When to Use Paigeant
-
-**Use Paigeant when:**
-- Your workflow spans multiple services or teams
-- Steps take significant time (minutes to hours)
-- Failure recovery is business-critical
-- You need to track complex business processes
-- You're building production AI systems
-
-**Don't use Paigeant when:**
-- Everything runs in a single process
-- You need millisecond response times  
-- The workflow is simple and unlikely to fail
-- You're just starting with AI agents (start simple first)
-
-## Installation & Setup
-
-### Installation
-
+## Development
 ```bash
-uv add paigeant
+uv pip install -e .[test]
+uv run pytest -q
 ```
-
-### Development Setup
-
-```bash
-git clone https://github.com/your-org/paigeant
-cd paigeant
-uv pip install -e .
-```
-
-### Configuration
-
-Configure your transport layer via environment variables:
-
-```bash
-# For development and testing
-export PAIGEANT_TRANSPORT=inmemory  # default
-
-# For production
-export PAIGEANT_TRANSPORT=rabbitmq
-export PAIGEANT_TRANSPORT=redis
-```
-
-### Testing
-
-Run the test suite:
-
-```bash
-uv run pytest tests/ -v
-```
-
-## Getting Started Guide
-
-1. **Think in workflows**: Break your business process into independent steps
-2. **Start small**: Begin with 2-3 steps to understand the pattern  
-3. **Add durability gradually**: Start with in-memory transport, upgrade to production brokers
-4. **Monitor and observe**: Use correlation IDs to track workflow progress
-5. **Scale up**: Add more complex workflows as your confidence grows
 
 ## Project Status
-
-**Early Development** - This is Feature 1 (Transport Layer) of the paigeant roadmap.
-
-**Current capabilities:**
-- Core message contracts and routing slip pattern
-- In-memory transport for development
-- Basic workflow dispatch and execution
-- pydantic-ai agent integration
-
-**Coming next:**
-- RabbitMQ and Redis transport implementations
-- Advanced routing slip execution engine  
-- Production worker runtime
-- State store integration for persistence
-- Comprehensive monitoring and observability
-
-## Contributing
-
-Paigeant is designed to solve real-world distributed AI challenges. We welcome contributions, especially:
-
-- Transport implementations (Kafka, Azure Service Bus, etc.)
-- Security enhancements (additional JOSE support)
-- Monitoring and observability features
-- Documentation and examples
+Early development. Implemented components: message contracts, workflow dispatcher, activity executor, `PaigeantAgent`, in-memory transport, Redis transport.
 
 ## License
-
-MIT License - see LICENSE file for details.
-
----
-
-*Paigeant transforms the complexity of distributed AI systems into manageable, resilient building blocks. It's not magic - it's proven architectural patterns applied to the unique challenges of AI agent orchestration.*
+MIT

--- a/guides/README.md
+++ b/guides/README.md
@@ -1,74 +1,34 @@
 # Paigeant Workflow Guides
 
-Examples showing how to implement workflow patterns with paigeant.
+Examples demonstrating distributed workflow patterns with `paigeant`.
 
-## Example Scripts
+## Example scripts
 
-### `dispatcher_example.py` - Workflow Dispatch Pattern
-Shows how to use `WorkflowDispatcher` with pydantic-ai agents to create distributed workflows.
+### `single_agent_example.py` — single agent workflow
+Shows registering a `PaigeantAgent` and dispatching work through `WorkflowDispatcher`.
 
-**Features:**
-- Multi-agent joke generation workflow using `PaigeantAgent`
-- Cross-agent dependency injection
-- Workflow coordination via dispatcher
+### `multi_agent_example.py` — sequential pipeline
+Runs three agents in order, passing outputs through queued messages.
 
-### `execution_example.py` - Activity Executor Pattern  
-Demonstrates how to run `ActivityExecutor` workers for handling workflow activities.
+### `dynamic_multi_agent_example.py` — dynamic itinerary editing
+Adds steps at runtime using an agent with `can_edit_itinerary=True`.
 
-**Features:**
-- Redis transport for cross-process messaging
-- Command-line agent loading
-- Activity execution infrastructure
+### `execution_example.py` — running workers
+Starts an `ActivityExecutor` process that consumes activities from the transport.
 
-### `three_agent_workflow_example.py` - Sequential Multi-Agent Workflow
-Shows a complete three-agent workflow with automatic message forwarding between agents.
-
-**Features:**
-- Sequential agent processing (input → enrichment → output)
-- Automatic message forwarding between workflow steps
-- Distributed execution across multiple worker processes
-- End-to-end workflow correlation tracking
-
-## Key Patterns
-
-### 1. PaigeantAgent vs Direct Calls
-```python
-# Paigeant: Specialized workflow agents
-joke_agent = PaigeantAgent(
-    "anthropic:claude-3-5-sonnet-latest",
-    deps_type=JokeWorkflowDeps,
-    system_prompt="Generate jokes using workflow tools"
-)
-
-# Workflow dispatch replaces direct agent calls
-correlation_id = await dispatcher.dispatch_workflow(activities)
-```
-
-### 2. Activity Execution
-```python
-# Worker process handling specific activities
-executor = ActivityExecutor(
-    transport, 
-    agent_name="joke-generator",
-    agent_path="guides.dispatcher_example"
-)
-await executor.start()  # Listens for workflow activities
-```
-
-## Running the Examples
+## Running the examples
 
 ```bash
-# Run workflow dispatcher example
-uv run python guides/dispatcher_example.py
+# Dispatch a single-agent workflow
+uv run python guides/single_agent_example.py
 
-# Run activity executor (requires Redis)
+# Start a worker for multi-agent examples (requires Redis)
 export PAIGEANT_TRANSPORT=redis
-uv run python guides/execution_example.py joke-generator guides.dispatcher_example
+uv run python guides/execution_example.py joke_generator_agent guides.multi_agent_example
 ```
 
-## Key Benefits
+## Key benefits
 
-- **Loose coupling** - Activities handled by separate processes
-- **Fault tolerance** - Individual activity failures don't crash workflows  
-- **Scalability** - Multiple workers can handle same activity type
-- **Observability** - Built-in correlation tracking across distributed activities
+- decoupled agents executed in separate processes
+- durable messaging isolates failures
+- workflows can edit itineraries at runtime


### PR DESCRIPTION
## Summary
- condense conceptual guide into concise overview of workflow problem, solution, and core components
- trim root README to highlight features and quick-start usage
- restore guides README with correct example scripts and worker instructions
- drop design document changes to retain original long-form spec

## Testing
- `uv run pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68965ae8c85c832e93587205de6c52d0