### PR TITLE
Allow agent lookup by name

### DIFF
--- a/CONCEPTUAL_GUIDE.md
+++ b/CONCEPTUAL_GUIDE.md
@@ -37,7 +37,7 @@ agent.add_to_runway(prompt="do work", deps=WorkflowDependencies())
 transport = get_transport()          # inmemory or redis
 correlation_id = await dispatcher.dispatch_workflow(transport)
 
-executor = ActivityExecutor(transport, "agent", "module.path")
+executor = ActivityExecutor(transport, "agent")
 await executor.start()
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Run a worker:
 ```python
 from paigeant import ActivityExecutor
 
-executor = ActivityExecutor(transport, "agent", "my.module")
+executor = ActivityExecutor(transport, "agent")
 await executor.start()
 ```
 

--- a/guides/README.md
+++ b/guides/README.md
@@ -24,7 +24,7 @@ uv run python guides/single_agent_example.py
 
 # Start a worker for multi-agent examples (requires Redis)
 export PAIGEANT_TRANSPORT=redis
-uv run python guides/execution_example.py joke_generator_agent guides.multi_agent_example
+uv run python guides/execution_example.py joke_generator_agent
 ```
 
 ## Key benefits

--- a/paigeant/agent/wrapper.py
+++ b/paigeant/agent/wrapper.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
+# Registry of all instantiated Paigeant agents keyed by name
+AGENT_REGISTRY: Dict[str, "PaigeantAgent"] = {}
+
 
 class PaigeantOutput(BaseModel, Generic[T]):
     """Base class for paigeant agent outputs."""
@@ -97,6 +100,10 @@ class PaigeantAgent(Agent):
         kwargs["output_type"] = _edit_itinerary_func
 
         super().__init__(*args, **kwargs)
+
+        # Register this agent instance by name for lookup during execution
+        agent_name = getattr(self, "name", self.agent_id)
+        AGENT_REGISTRY[agent_name] = self
 
         self._instructions_functions.append(
             _system_prompt.SystemPromptRunner(_extract_previous_output, dynamic=True)

--- a/paigeant/cli.py
+++ b/paigeant/cli.py
@@ -11,12 +11,10 @@ app = typer.Typer(help="CLI for Paigeant workflows")
 
 
 @app.command()
-def execute(agent_name: str, agent_path: str) -> None:
+def execute(agent_name: str) -> None:
     """Run an ActivityExecutor for the given agent."""
     transport = get_transport()
-    executor = ActivityExecutor(
-        transport, agent_name=agent_name, agent_path=agent_path
-    )
+    executor = ActivityExecutor(transport, agent_name=agent_name)
     asyncio.run(executor.start())
 
 

--- a/paigeant/execute.py
+++ b/paigeant/execute.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import logging
-from importlib import import_module
 from typing import Any
 
 from pydantic_ai import Agent
 
-from paigeant.agent.wrapper import PaigeantOutput
+from paigeant.agent.wrapper import AGENT_REGISTRY
 from paigeant.deps.deserializer import DependencyDeserializer
 
 from .contracts import (
@@ -25,12 +24,9 @@ logger = logging.getLogger(__name__)
 class ActivityExecutor:
     """Executes workflow activities by listening to transport messages."""
 
-    def __init__(
-        self, transport: BaseTransport, agent_name: str, agent_path: str
-    ) -> None:
+    def __init__(self, transport: BaseTransport, agent_name: str) -> None:
         self._transport = transport
         self._agent_name = agent_name
-        self._agent_path = agent_path
         self.executed_activities = []
 
     def extract_activity(self, message: PaigeantMessage) -> ActivitySpec:
@@ -51,10 +47,12 @@ class ActivityExecutor:
     ) -> None:
         """Handle incoming workflow activity."""
         print(f"Received activity: {activity}")
-        print(f"Agent path: {self._agent_path}, Agent name: {self._agent_name}")
+        print(f"Agent name: {self._agent_name}")
 
-        agent_module = import_module(self._agent_path)
-        agent: Agent = getattr(agent_module, self._agent_name, None)
+        agent: Agent | None = AGENT_REGISTRY.get(self._agent_name)
+        if agent is None:
+            raise ValueError(f"Agent {self._agent_name} not found in registry")
+        agent_module = agent.__module__
 
         raw_deps: Any = None
         if activity.deps and activity.deps.data:
@@ -63,7 +61,7 @@ class ActivityExecutor:
                     deps_data=activity.deps.data,
                     deps_type=activity.deps.type,
                     deps_module=activity.deps.module,
-                    fallback_module=self._agent_path,
+                    fallback_module=agent_module,
                 )
             except Exception as e:
                 print(f"Failed to deserialize deps: {e}")

--- a/tests/integration/test_multi_agent.py
+++ b/tests/integration/test_multi_agent.py
@@ -70,7 +70,6 @@ async def test_two_agent_integration(mock_get):
     # Agent definitions
     first_agent_name = "joke_processor_agent"
     second_agent_name = "joke_formatter_agent"
-    agent_path = "tests.integration.test_multi_agent"
 
     transport = get_transport()
 
@@ -101,9 +100,7 @@ async def test_two_agent_integration(mock_get):
     assert first_queue_before > 0, "First agent should have message in queue"
 
     # Run first executor
-    first_executor = ActivityExecutor(
-        transport, agent_name=first_agent_name, agent_path=agent_path
-    )
+    first_executor = ActivityExecutor(transport, agent_name=first_agent_name)
     await first_executor.start(timeout=5)
 
     # Verify first agent processed and second agent received message
@@ -122,9 +119,7 @@ async def test_two_agent_integration(mock_get):
     ), "Second agent should have received forwarded message"
 
     # Run second executor
-    second_executor = ActivityExecutor(
-        transport, agent_name=second_agent_name, agent_path=agent_path
-    )
+    second_executor = ActivityExecutor(transport, agent_name=second_agent_name)
     await second_executor.start(timeout=5)
 
     # Verify second agent processed

--- a/tests/integration/test_single_agent.py
+++ b/tests/integration/test_single_agent.py
@@ -70,7 +70,6 @@ async def test_single_agent_integration(mock_get):
     # Setup workflow infrastructure
     os.environ["PAIGEANT_TRANSPORT"] = "redis"
     agent_name = "joke_generation_agent"
-    agent_path = "tests.integration.test_single_agent"
 
     transport = get_transport()
 
@@ -95,7 +94,7 @@ async def test_single_agent_integration(mock_get):
     assert queue_length_before > 0, "Message should be in queue after dispatch"
 
     transport = get_transport()
-    executor = ActivityExecutor(transport, agent_name=agent_name, agent_path=agent_path)
+    executor = ActivityExecutor(transport, agent_name=agent_name)
 
     # Start executor
     await executor.start(timeout=5)


### PR DESCRIPTION
## Summary
- Load agents via a global registry keyed by name
- Simplify ActivityExecutor and CLI to accept only an agent name
- Update tests to reflect registry-based lookup while restoring original integration test behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx'; ModuleNotFoundError: No module named 'pydantic'; ModuleNotFoundError: No module named 'paigeant')*

------
https://chatgpt.com/codex/tasks/task_e_6897555ae478832e9d3938084dee7840