### PR TITLE
Add YAML-based transport configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ dispatcher = WorkflowDispatcher()
 agent = PaigeantAgent("anthropic:claude-3-5", dispatcher=dispatcher, deps_type=WorkflowDependencies)
 agent.add_to_runway(prompt="do work", deps=WorkflowDependencies())
 
-transport = get_transport()  # in-memory by default or set PAIGEANT_TRANSPORT=redis
+transport = get_transport()  # in-memory by default, configurable via PAIGEANT_TRANSPORT or config.yaml
 correlation_id = await dispatcher.dispatch_workflow(transport)
 ```
 

--- a/paigeant/config.py
+++ b/paigeant/config.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import os
+from typing import Optional, Literal
+
+import yaml
+from pydantic import BaseModel
+
+
+class RedisConfig(BaseModel):
+    """Configuration for Redis transport."""
+
+    host: str = "localhost"
+    port: int = 6379
+    db: int = 0
+    password: Optional[str] = None
+
+
+class TransportConfig(BaseModel):
+    """Transport configuration settings."""
+
+    backend: Literal["inmemory", "redis"] = "inmemory"
+    redis: RedisConfig = RedisConfig()
+
+
+class PaigeantConfig(BaseModel):
+    """Top-level configuration model."""
+
+    transport: TransportConfig = TransportConfig()
+
+
+def load_config(path: Optional[str] = None) -> PaigeantConfig:
+    """Load configuration from YAML file.
+
+    Args:
+        path: Optional path to config file. Falls back to PAIGENT_CONFIG env
+            variable or 'config.yaml' in the current directory.
+    """
+
+    config_path = path or os.getenv("PAIGENT_CONFIG", "config.yaml")
+    if os.path.exists(config_path):
+        with open(config_path) as f:
+            data = yaml.safe_load(f) or {}
+        return PaigeantConfig(**data)
+    return PaigeantConfig()

--- a/paigeant/transports/__init__.py
+++ b/paigeant/transports/__init__.py
@@ -5,27 +5,34 @@ from __future__ import annotations
 import os
 from typing import Optional
 
+from ..config import PaigeantConfig, load_config
 from .base import BaseTransport
 from .inmemory import InMemoryTransport
 
 
-def get_transport(backend: Optional[str] = None) -> BaseTransport:
+def get_transport(
+    backend: Optional[str] = None, config: Optional[PaigeantConfig] = None
+) -> BaseTransport:
     """Factory function to get the configured transport."""
+
+    config = config or load_config()
     backend = (
-        os.getenv("PAIGEANT_TRANSPORT", "inmemory").lower()
-        if not backend
-        else backend.lower()
-    )
+        backend
+        or os.getenv("PAIGEANT_TRANSPORT")
+        or config.transport.backend
+    ).lower()
 
     if backend == "inmemory":
         return InMemoryTransport()
     elif backend == "redis":
         from .redis import RedisTransport
 
+        redis_conf = config.transport.redis
         return RedisTransport(
-            host=os.getenv("REDIS_HOST", "localhost"),
-            port=int(os.getenv("REDIS_PORT", "6379")),
-            password=os.getenv("REDIS_PASSWORD"),
+            host=redis_conf.host,
+            port=redis_conf.port,
+            db=redis_conf.db,
+            password=redis_conf.password,
         )
     else:
         raise ValueError(f"Unsupported transport backend: {backend}")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,43 @@
+"""Tests for configuration loading."""
+
+from paigeant.config import load_config
+from paigeant.transports import get_transport
+from paigeant.transports.redis import RedisTransport
+
+
+def test_load_config_from_env(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+transport:
+  backend: redis
+  redis:
+    host: testhost
+    port: 1234
+"""
+    )
+    monkeypatch.setenv("PAIGENT_CONFIG", str(config_path))
+
+    config = load_config()
+    assert config.transport.backend == "redis"
+    assert config.transport.redis.host == "testhost"
+    assert config.transport.redis.port == 1234
+
+
+def test_get_transport_uses_config(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+transport:
+  backend: redis
+  redis:
+    host: confighost
+    port: 6380
+"""
+    )
+    monkeypatch.setenv("PAIGENT_CONFIG", str(config_path))
+
+    transport = get_transport()
+    assert isinstance(transport, RedisTransport)
+    assert transport.host == "confighost"
+    assert transport.port == 6380


### PR DESCRIPTION
## Summary
- support transport configuration via `config.yaml` with a Pydantic model
- allow overriding config path via `PAIGENT_CONFIG`
- update transport factory and docs accordingly
- add unit tests for loading configuration

## Testing
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'tests' in integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_689760c60a58832e82814c4a1820b45b