### PR TITLE
feat: auto-discover agents in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ correlation_id = await dispatcher.dispatch_workflow(transport)
 An `ActivityExecutor` pulls messages from the transport and executes the agent's activity. Start one using the CLI:
 
 ```bash
-uv run paigeant execute agent my.module
+uv run paigeant execute agent
 ```
 
 ## Transports

--- a/guides/README.md
+++ b/guides/README.md
@@ -23,7 +23,7 @@ uv run python guides/single_agent_example.py
 
 # Start a worker for multi-agent examples (requires Redis)
 export PAIGEANT_TRANSPORT=redis
-uv run paigeant execute joke_generator_agent guides.multi_agent_example
+uv run paigeant execute joke_generator_agent
 ```
 
 ## Key benefits

--- a/guides/dynamic_multi_agent_example.py
+++ b/guides/dynamic_multi_agent_example.py
@@ -142,13 +142,13 @@ Workflow dispatched with correlation ID: {correlation_id}
 To run the workers for each agent, start these in separate terminals:
 
 1. Topic extractor worker:
-uv run paigeant execute topic_extractor_agent guides.three_agent_workflow_example
+uv run paigeant execute topic_extractor_agent
 
 2. Joke generator worker:
-uv run paigeant execute joke_generator_agent guides.three_agent_workflow_example
+uv run paigeant execute joke_generator_agent
 
 3. Joke selector worker:
-uv run paigeant execute joke_selector_agent guides.three_agent_workflow_example
+uv run paigeant execute joke_selector_agent
 """
     )
 

--- a/guides/multi_agent_example.py
+++ b/guides/multi_agent_example.py
@@ -125,13 +125,13 @@ Workflow dispatched with correlation ID: {correlation_id}
 To run the workers for each agent, start these in separate terminals:
 
 1. Topic extractor worker:
-uv run paigeant execute topic_extractor_agent guides.three_agent_workflow_example
+uv run paigeant execute topic_extractor_agent
 
 2. Joke generator worker:
-uv run paigeant execute joke_generator_agent guides.three_agent_workflow_example
+uv run paigeant execute joke_generator_agent
 
 3. Joke selector worker:
-uv run paigeant execute joke_selector_agent guides.three_agent_workflow_example
+uv run paigeant execute joke_selector_agent
 """
     )
 

--- a/paigeant/agent/discovery.py
+++ b/paigeant/agent/discovery.py
@@ -1,0 +1,39 @@
+"""Utilities for discovering Paigeant agents in the environment."""
+
+from __future__ import annotations
+
+import pkgutil
+from importlib import import_module
+from pathlib import Path
+
+from .wrapper import AGENT_REGISTRY
+
+
+def discover_agent(agent_name: str) -> None:
+    """Import available modules to locate an agent by name.
+
+    This performs a best-effort scan of modules on the current working
+    directory's ``sys.path``. Any module that defines a ``PaigeantAgent``
+    with a matching ``name`` will register itself in ``AGENT_REGISTRY``
+    when imported. The scan stops once the requested agent is found.
+
+    Raises:
+        ValueError: If no agent with ``agent_name`` can be located.
+    """
+
+    if agent_name in AGENT_REGISTRY:
+        return
+
+    search_path = [str(Path.cwd())]
+    for module in pkgutil.walk_packages(search_path):
+        module_name = module.name
+        if module_name.startswith("paigeant"):
+            continue
+        try:
+            import_module(module_name)
+        except Exception:
+            continue
+        if agent_name in AGENT_REGISTRY:
+            return
+
+    raise ValueError(f"Agent {agent_name} not found in available modules")

--- a/paigeant/cli.py
+++ b/paigeant/cli.py
@@ -1,12 +1,12 @@
 """Command line interface for running Paigeant workers."""
 
 import asyncio
-from importlib import import_module
 from typing import Optional
 
 import typer
 
 from paigeant import ActivityExecutor, get_transport
+from paigeant.agent.discovery import discover_agent
 
 app = typer.Typer(help="CLI for Paigeant workflows")
 
@@ -18,9 +18,9 @@ def main() -> None:
 
 
 @app.command()
-def execute(agent_name: str, agent_path: str, lifespan: Optional[float] = None) -> None:
+def execute(agent_name: str, lifespan: Optional[float] = None) -> None:
     """Run an ActivityExecutor for the given agent."""
-    import_module(agent_path)
+    discover_agent(agent_name)
     transport = get_transport()
     executor = ActivityExecutor(transport, agent_name=agent_name)
     asyncio.run(executor.start(lifespan=lifespan))


### PR DESCRIPTION
## Summary
- remove module path requirement from `paigeant execute`
- auto-discover agents before running an executor
- update dynamic CLI integration test to use Typer runner with minimal mocking
- refresh docs for simplified CLI usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898be0270c0832ead300dc541ff1aab