### PR TITLE
feat: add initial workflow persistence layer

### DIFF
--- a/paigeant/persistence/__init__.py
+++ b/paigeant/persistence/__init__.py
@@ -1,0 +1,18 @@
+"""Persistence layer for Paigeant workflows."""
+
+from .models import StepRecord, WorkflowInstance
+from .repository import WorkflowRepository
+from .sqlite import SQLiteWorkflowRepository
+
+try:  # pragma: no cover - optional dependency
+    from .postgres import PostgresWorkflowRepository
+except Exception:  # pragma: no cover - optional dependency
+    PostgresWorkflowRepository = None  # type: ignore
+
+__all__ = [
+    "StepRecord",
+    "WorkflowInstance",
+    "WorkflowRepository",
+    "SQLiteWorkflowRepository",
+    "PostgresWorkflowRepository",
+]

--- a/paigeant/persistence/models.py
+++ b/paigeant/persistence/models.py
@@ -1,0 +1,30 @@
+"""Data models for persisted workflow state."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from pydantic import BaseModel, Field
+
+
+class StepRecord(BaseModel):
+    """Record of an individual step execution."""
+
+    id: Optional[int] = None
+    correlation_id: str
+    step_name: str
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+    status: Optional[str] = None
+    output: Optional[dict[str, Any]] = None
+
+
+class WorkflowInstance(BaseModel):
+    """Persisted workflow instance data."""
+
+    correlation_id: str
+    routing_slip: dict[str, Any] = Field(default_factory=dict)
+    payload: dict[str, Any] | None = None
+    status: str = "in_progress"
+    steps: list[StepRecord] = Field(default_factory=list)

--- a/paigeant/persistence/postgres.py
+++ b/paigeant/persistence/postgres.py
@@ -1,0 +1,174 @@
+"""PostgreSQL implementation of the workflow repository."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any
+
+import asyncpg
+
+from .models import StepRecord, WorkflowInstance
+from .repository import WorkflowRepository
+
+
+class PostgresWorkflowRepository(WorkflowRepository):
+    """Persist workflow state using PostgreSQL."""
+
+    def __init__(self, dsn: str):
+        self._dsn = dsn
+        self._initialized = False
+
+    async def _connect(self) -> asyncpg.Connection:
+        conn = await asyncpg.connect(self._dsn)
+        if not self._initialized:
+            await self._ensure_schema(conn)
+            self._initialized = True
+        return conn
+
+    async def _ensure_schema(self, conn: asyncpg.Connection) -> None:
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS workflows (
+                correlation_id TEXT PRIMARY KEY,
+                routing_slip JSONB NOT NULL,
+                payload JSONB,
+                status TEXT NOT NULL
+            )
+            """
+        )
+        await conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS step_history (
+                id SERIAL PRIMARY KEY,
+                correlation_id TEXT NOT NULL,
+                step_name TEXT NOT NULL,
+                started_at TIMESTAMPTZ,
+                completed_at TIMESTAMPTZ,
+                status TEXT,
+                output JSONB
+            )
+            """
+        )
+
+    # ------------------------------------------------------------------
+    async def create_workflow(
+        self, correlation_id: str, routing_slip: dict, payload: dict | None = None
+    ) -> None:
+        conn = await self._connect()
+        try:
+            await conn.execute(
+                "INSERT INTO workflows (correlation_id, routing_slip, payload, status) VALUES ($1, $2, $3, $4)",
+                correlation_id,
+                json.dumps(routing_slip),
+                json.dumps(payload or {}),
+                "in_progress",
+            )
+        finally:
+            await conn.close()
+
+    async def update_routing_slip(self, correlation_id: str, routing_slip: dict) -> None:
+        conn = await self._connect()
+        try:
+            await conn.execute(
+                "UPDATE workflows SET routing_slip = $1 WHERE correlation_id = $2",
+                json.dumps(routing_slip),
+                correlation_id,
+            )
+        finally:
+            await conn.close()
+
+    async def mark_step_started(self, correlation_id: str, step_name: str) -> None:
+        conn = await self._connect()
+        try:
+            await conn.execute(
+                "INSERT INTO step_history (correlation_id, step_name, started_at) VALUES ($1, $2, $3)",
+                correlation_id,
+                step_name,
+                datetime.utcnow(),
+            )
+        finally:
+            await conn.close()
+
+    async def mark_step_completed(
+        self,
+        correlation_id: str,
+        step_name: str,
+        status: str,
+        output: dict | None = None,
+    ) -> None:
+        conn = await self._connect()
+        try:
+            await conn.execute(
+                """
+                UPDATE step_history
+                SET completed_at = $1, status = $2, output = $3
+                WHERE correlation_id = $4 AND step_name = $5
+                """,
+                datetime.utcnow(),
+                status,
+                json.dumps(output or {}),
+                correlation_id,
+                step_name,
+            )
+        finally:
+            await conn.close()
+
+    async def update_payload(self, correlation_id: str, payload: dict) -> None:
+        conn = await self._connect()
+        try:
+            await conn.execute(
+                "UPDATE workflows SET payload = $1 WHERE correlation_id = $2",
+                json.dumps(payload),
+                correlation_id,
+            )
+        finally:
+            await conn.close()
+
+    async def mark_workflow_completed(
+        self, correlation_id: str, status: str = "completed"
+    ) -> None:
+        conn = await self._connect()
+        try:
+            await conn.execute(
+                "UPDATE workflows SET status = $1 WHERE correlation_id = $2",
+                status,
+                correlation_id,
+            )
+        finally:
+            await conn.close()
+
+    async def get_workflow(self, correlation_id: str) -> WorkflowInstance | None:
+        conn = await self._connect()
+        try:
+            row = await conn.fetchrow(
+                "SELECT correlation_id, routing_slip, payload, status FROM workflows WHERE correlation_id = $1",
+                correlation_id,
+            )
+            if not row:
+                return None
+            steps_rows = await conn.fetch(
+                "SELECT id, correlation_id, step_name, started_at, completed_at, status, output FROM step_history WHERE correlation_id = $1 ORDER BY id",
+                correlation_id,
+            )
+        finally:
+            await conn.close()
+        steps = [
+            StepRecord(
+                id=r["id"],
+                correlation_id=r["correlation_id"],
+                step_name=r["step_name"],
+                started_at=r["started_at"],
+                completed_at=r["completed_at"],
+                status=r["status"],
+                output=r["output"],
+            )
+            for r in steps_rows
+        ]
+        return WorkflowInstance(
+            correlation_id=row["correlation_id"],
+            routing_slip=row["routing_slip"],
+            payload=row["payload"],
+            status=row["status"],
+            steps=steps,
+        )

--- a/paigeant/persistence/repository.py
+++ b/paigeant/persistence/repository.py
@@ -1,0 +1,42 @@
+"""Repository abstraction for workflow state persistence."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from .models import WorkflowInstance
+
+
+class WorkflowRepository(Protocol):
+    """Protocol for workflow state persistence backends."""
+
+    async def create_workflow(
+        self, correlation_id: str, routing_slip: dict, payload: dict | None = None
+    ) -> None:
+        """Persist initial workflow state."""
+
+    async def update_routing_slip(self, correlation_id: str, routing_slip: dict) -> None:
+        """Persist updated routing slip."""
+
+    async def mark_step_started(self, correlation_id: str, step_name: str) -> None:
+        """Record start of a step."""
+
+    async def mark_step_completed(
+        self,
+        correlation_id: str,
+        step_name: str,
+        status: str,
+        output: dict | None = None,
+    ) -> None:
+        """Record completion of a step."""
+
+    async def update_payload(self, correlation_id: str, payload: dict) -> None:
+        """Persist workflow payload updates."""
+
+    async def mark_workflow_completed(
+        self, correlation_id: str, status: str = "completed"
+    ) -> None:
+        """Mark the workflow as finished."""
+
+    async def get_workflow(self, correlation_id: str) -> WorkflowInstance | None:
+        """Retrieve the workflow instance by id."""

--- a/paigeant/persistence/sqlite.py
+++ b/paigeant/persistence/sqlite.py
@@ -1,0 +1,172 @@
+"""SQLite implementation of the workflow repository."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .models import StepRecord, WorkflowInstance
+from .repository import WorkflowRepository
+
+
+class SQLiteWorkflowRepository(WorkflowRepository):
+    """Persist workflow state using SQLite."""
+
+    def __init__(self, db_path: str | Path):
+        self.db_path = str(db_path)
+        self._conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._ensure_schema()
+
+    # ------------------------------------------------------------------
+    # Schema management
+    def _ensure_schema(self) -> None:
+        cur = self._conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS workflows (
+                correlation_id TEXT PRIMARY KEY,
+                routing_slip TEXT NOT NULL,
+                payload TEXT,
+                status TEXT NOT NULL
+            )
+            """
+        )
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS step_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                correlation_id TEXT NOT NULL,
+                step_name TEXT NOT NULL,
+                started_at TEXT,
+                completed_at TEXT,
+                status TEXT,
+                output TEXT
+            )
+            """
+        )
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Helper methods
+    def _execute(self, query: str, *params: Any) -> None:
+        cur = self._conn.cursor()
+        cur.execute(query, params)
+        self._conn.commit()
+
+    def _fetchone(self, query: str, *params: Any) -> sqlite3.Row | None:
+        cur = self._conn.cursor()
+        cur.execute(query, params)
+        return cur.fetchone()
+
+    def _fetchall(self, query: str, *params: Any) -> list[sqlite3.Row]:
+        cur = self._conn.cursor()
+        cur.execute(query, params)
+        return cur.fetchall()
+
+    # ------------------------------------------------------------------
+    # Repository API
+    async def create_workflow(
+        self, correlation_id: str, routing_slip: dict, payload: dict | None = None
+    ) -> None:
+        await asyncio.to_thread(
+            self._execute,
+            "INSERT INTO workflows (correlation_id, routing_slip, payload, status) VALUES (?, ?, ?, ?)",
+            correlation_id,
+            json.dumps(routing_slip),
+            json.dumps(payload or {}),
+            "in_progress",
+        )
+
+    async def update_routing_slip(self, correlation_id: str, routing_slip: dict) -> None:
+        await asyncio.to_thread(
+            self._execute,
+            "UPDATE workflows SET routing_slip = ? WHERE correlation_id = ?",
+            json.dumps(routing_slip),
+            correlation_id,
+        )
+
+    async def mark_step_started(self, correlation_id: str, step_name: str) -> None:
+        await asyncio.to_thread(
+            self._execute,
+            "INSERT INTO step_history (correlation_id, step_name, started_at) VALUES (?, ?, ?)",
+            correlation_id,
+            step_name,
+            datetime.utcnow().isoformat(),
+        )
+
+    async def mark_step_completed(
+        self,
+        correlation_id: str,
+        step_name: str,
+        status: str,
+        output: dict | None = None,
+    ) -> None:
+        await asyncio.to_thread(
+            self._execute,
+            """
+            UPDATE step_history
+            SET completed_at = ?, status = ?, output = ?
+            WHERE correlation_id = ? AND step_name = ?
+            """,
+            datetime.utcnow().isoformat(),
+            status,
+            json.dumps(output or {}),
+            correlation_id,
+            step_name,
+        )
+
+    async def update_payload(self, correlation_id: str, payload: dict) -> None:
+        await asyncio.to_thread(
+            self._execute,
+            "UPDATE workflows SET payload = ? WHERE correlation_id = ?",
+            json.dumps(payload),
+            correlation_id,
+        )
+
+    async def mark_workflow_completed(
+        self, correlation_id: str, status: str = "completed"
+    ) -> None:
+        await asyncio.to_thread(
+            self._execute,
+            "UPDATE workflows SET status = ? WHERE correlation_id = ?",
+            status,
+            correlation_id,
+        )
+
+    async def get_workflow(self, correlation_id: str) -> WorkflowInstance | None:
+        row = await asyncio.to_thread(
+            self._fetchone,
+            "SELECT correlation_id, routing_slip, payload, status FROM workflows WHERE correlation_id = ?",
+            correlation_id,
+        )
+        if not row:
+            return None
+        steps_rows = await asyncio.to_thread(
+            self._fetchall,
+            "SELECT id, correlation_id, step_name, started_at, completed_at, status, output FROM step_history WHERE correlation_id = ? ORDER BY id",
+            correlation_id,
+        )
+        steps = [
+            StepRecord(
+                id=r["id"],
+                correlation_id=r["correlation_id"],
+                step_name=r["step_name"],
+                started_at=datetime.fromisoformat(r["started_at"]) if r["started_at"] else None,
+                completed_at=datetime.fromisoformat(r["completed_at"]) if r["completed_at"] else None,
+                status=r["status"],
+                output=json.loads(r["output"]) if r["output"] else None,
+            )
+            for r in steps_rows
+        ]
+        return WorkflowInstance(
+            correlation_id=row["correlation_id"],
+            routing_slip=json.loads(row["routing_slip"]),
+            payload=json.loads(row["payload"]) if row["payload"] else None,
+            status=row["status"],
+            steps=steps,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "pydantic>=2.11.7",
     "pydantic-ai>=0.4.7",
     "typer>=0.9.0",
+    "asyncpg>=0.29.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit/test_persistence_repository.py
+++ b/tests/unit/test_persistence_repository.py
@@ -1,0 +1,34 @@
+import uuid
+
+import pytest
+
+from paigeant.persistence import SQLiteWorkflowRepository
+
+
+@pytest.mark.asyncio
+async def test_sqlite_repository_crud(tmp_path):
+    db_path = tmp_path / "wf.db"
+    repo = SQLiteWorkflowRepository(db_path)
+
+    corr_id = str(uuid.uuid4())
+    routing_slip = {"itinerary": ["step1"]}
+    payload = {"foo": "bar"}
+
+    await repo.create_workflow(corr_id, routing_slip, payload)
+    await repo.mark_step_started(corr_id, "step1")
+    await repo.mark_step_completed(corr_id, "step1", status="completed", output={"x": 1})
+    await repo.update_payload(corr_id, {"foo": "baz"})
+    await repo.update_routing_slip(corr_id, {"itinerary": []})
+    await repo.mark_workflow_completed(corr_id)
+
+    wf = await repo.get_workflow(corr_id)
+    assert wf is not None
+    assert wf.correlation_id == corr_id
+    assert wf.routing_slip == {"itinerary": []}
+    assert wf.payload == {"foo": "baz"}
+    assert wf.status == "completed"
+    assert len(wf.steps) == 1
+    step = wf.steps[0]
+    assert step.step_name == "step1"
+    assert step.status == "completed"
+    assert step.output == {"x": 1}


### PR DESCRIPTION
## Summary
- define workflow persistence models and protocol
- implement SQLite and PostgreSQL repositories
- cover SQLite repository with unit tests

## Testing
- `python -m pip install -e .[test]`
- `redis-server --daemonize yes`
- `pytest tests/unit`
- `PAIGEANT_TRANSPORT=inmemory pytest` *(fails: anthropic.APIConnectionError: Connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68b1af2996fc832e96dc21f59b33d706