### PR TITLE
feat: add configurable workflow persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ If an agent crashes, the message stays in the queue until a worker handles it.
 - **WorkflowDispatcher** – builds a routing slip and publishes the initial message.
 - **PaigeantAgent** – thin wrapper around `pydantic_ai.Agent` with optional itinerary editing and access to previous outputs.
 - **ActivityExecutor** – worker that subscribes to a topic, runs the agent, and forwards the message.
+- **WorkflowRepository** – optional persistence layer for querying workflow state.
 
 ## Architectural Principles
 1. **Asynchronous communication** – every step is delivered over the transport.
@@ -54,11 +55,25 @@ transport = get_transport()  # in-memory by default, configurable via PAIGEANT_T
 correlation_id = await dispatcher.dispatch_workflow(transport)
 ```
 
+To enable state persistence, set a database URL via `PAIGEANT_DATABASE_URL` or
+`DATABASE_URL`. SQLite is supported out of the box:
+
+```bash
+export PAIGEANT_DATABASE_URL=sqlite:///paigeant.db
+```
+
 ### Run a worker
 An `ActivityExecutor` pulls messages from the transport and executes the agent's activity. Start one using the CLI:
 
 ```bash
 uv run paigeant execute agent
+```
+
+Inspect workflow progress using the CLI:
+
+```bash
+uv run paigeant workflows            # list all workflows
+uv run paigeant workflow <id>        # show details for a workflow
 ```
 
 ## Transports

--- a/guides/single_agent_example.py
+++ b/guides/single_agent_example.py
@@ -10,6 +10,7 @@ from paigeant import (
     PaigeantAgent,
     WorkflowDependencies,
     WorkflowDispatcher,
+    get_repository,
     get_transport,
 )
 
@@ -57,6 +58,7 @@ async def main():
     print("Running joke selection agent with paigeant workflow...")
     # Setup workflow infrastructure
     transport = get_transport()
+    repository = get_repository()
 
     http_key = HttpKey(api_key="foobar")
     deps = JokeWorkflowDeps(
@@ -70,6 +72,8 @@ async def main():
     )
 
     correlation_id = await dispatcher.dispatch_workflow(transport)
+    wf = await repository.get_workflow(correlation_id)
+    print("Persisted status:", wf.status)
 
 
 if __name__ == "__main__":

--- a/paigeant/__init__.py
+++ b/paigeant/__init__.py
@@ -5,6 +5,7 @@ from .contracts import ActivitySpec, PaigeantMessage, RoutingSlip, WorkflowDepen
 from .dispatch import WorkflowDispatcher
 from .execute import ActivityExecutor
 from .transports import get_transport
+from .persistence import get_repository
 
 __version__ = "0.1.0"
 __all__ = [
@@ -14,6 +15,7 @@ __all__ = [
     "PaigeantMessage",
     "WorkflowDispatcher",
     "get_transport",
+    "get_repository",
     "PaigeantAgent",
     "WorkflowDependencies",
 ]

--- a/paigeant/cli.py
+++ b/paigeant/cli.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 import typer
 
-from paigeant import ActivityExecutor, get_transport
+from paigeant import ActivityExecutor, get_repository, get_transport
 from paigeant.agent.discovery import discover_agent
 
 app = typer.Typer(help="CLI for Paigeant workflows")
@@ -26,9 +26,46 @@ def execute(
 ) -> None:
     """Run an ActivityExecutor for the given agent."""
     transport = get_transport()
-    executor = ActivityExecutor(transport, agent_name=agent_name, base_path=base_path)
+    repository = get_repository()
+    executor = ActivityExecutor(
+        transport, agent_name=agent_name, base_path=base_path, repository=repository
+    )
     print("Starting agent:", agent_name)
     asyncio.run(executor.start(lifespan=lifespan))
+
+
+@app.command()
+def workflows() -> None:
+    """List workflows in the repository."""
+    repo = get_repository()
+    workflows = asyncio.run(repo.list_workflows())
+    if not workflows:
+        typer.echo("No workflows found")
+        return
+    for wf in workflows:
+        typer.echo(f"{wf.correlation_id}\t{wf.status}")
+
+
+@app.command()
+def workflow(correlation_id: str) -> None:
+    """Show details for a workflow."""
+    repo = get_repository()
+    wf = asyncio.run(repo.get_workflow(correlation_id))
+    if wf is None:
+        typer.echo("Workflow not found")
+        raise typer.Exit(code=1)
+    typer.echo(f"Workflow {wf.correlation_id}: {wf.status}")
+    if wf.payload:
+        typer.echo(f"Payload: {wf.payload}")
+    for step in wf.steps:
+        typer.echo(
+            f"- {step.step_name}: {step.status}"
+            + (
+                f" ({step.started_at} -> {step.completed_at})"
+                if step.started_at or step.completed_at
+                else ""
+            )
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry point

--- a/paigeant/config.py
+++ b/paigeant/config.py
@@ -27,6 +27,7 @@ class PaigeantConfig(BaseModel):
     """Top-level configuration model."""
 
     transport: TransportConfig = TransportConfig()
+    database_url: Optional[str] = None
 
 
 def load_config(path: Optional[str] = None) -> PaigeantConfig:
@@ -41,5 +42,11 @@ def load_config(path: Optional[str] = None) -> PaigeantConfig:
     if os.path.exists(config_path):
         with open(config_path) as f:
             data = yaml.safe_load(f) or {}
-        return PaigeantConfig(**data)
-    return PaigeantConfig()
+        config = PaigeantConfig(**data)
+    else:
+        config = PaigeantConfig()
+
+    env_db_url = os.getenv("PAIGEANT_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if env_db_url:
+        config.database_url = env_db_url
+    return config

--- a/paigeant/dispatch.py
+++ b/paigeant/dispatch.py
@@ -18,7 +18,7 @@ from .contracts import (
     SerializedDeps,
 )
 from .deps.serializer import DependencySerializer
-from .persistence import WorkflowRepository
+from .persistence import WorkflowRepository, get_repository
 from .transports import BaseTransport
 
 
@@ -105,6 +105,7 @@ class WorkflowDispatcher:
             activity_registry=self._activity_registry,
         )
 
+        repository = repository or get_repository()
         if repository is not None:
             try:
                 await repository.create_workflow(

--- a/paigeant/execute.py
+++ b/paigeant/execute.py
@@ -21,7 +21,7 @@ from .contracts import (
     PreviousOutput,
     WorkflowDependencies,
 )
-from .persistence import WorkflowRepository
+from .persistence import WorkflowRepository, get_repository
 from .transports import BaseTransport
 
 logger = logging.getLogger(__name__)
@@ -41,7 +41,7 @@ class ActivityExecutor:
         self._agent_name = agent_name
         self.agent: Agent = discover_agent(agent_name, base_path)
         self.executed_activities = []
-        self._repository = repository
+        self._repository = repository or get_repository()
 
     def extract_activity(self, message: PaigeantMessage) -> ActivitySpec:
         """Return the next activity from the message's routing slip."""

--- a/paigeant/persistence/__init__.py
+++ b/paigeant/persistence/__init__.py
@@ -1,5 +1,12 @@
 """Persistence layer for Paigeant workflows."""
 
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from ..config import PaigeantConfig, load_config
+from .inmemory import InMemoryWorkflowRepository
 from .models import StepRecord, WorkflowInstance
 from .repository import WorkflowRepository
 from .sqlite import SQLiteWorkflowRepository
@@ -9,10 +16,57 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - optional dependency
     PostgresWorkflowRepository = None  # type: ignore
 
+_repository_instance: WorkflowRepository | None = None
+
+
+def get_repository(
+    database_url: Optional[str] = None, config: Optional[PaigeantConfig] = None
+) -> WorkflowRepository:
+    """Factory function to obtain a workflow repository.
+
+    The repository backend is selected based on ``database_url`` which can be
+    provided explicitly, via environment variable ``PAIGEANT_DATABASE_URL`` or
+    ``DATABASE_URL``, or from loaded configuration. When no database is
+    configured, an in-memory repository is returned.
+    """
+
+    global _repository_instance
+    if _repository_instance is not None and database_url is None and config is None:
+        return _repository_instance
+
+    config = config or load_config()
+    database_url = (
+        database_url
+        or os.getenv("PAIGEANT_DATABASE_URL")
+        or os.getenv("DATABASE_URL")
+        or getattr(config, "database_url", None)
+    )
+
+    if not database_url:
+        _repository_instance = InMemoryWorkflowRepository()
+        return _repository_instance
+
+    if database_url.startswith("sqlite://"):
+        path = database_url.replace("sqlite://", "", 1)
+        _repository_instance = SQLiteWorkflowRepository(path)
+    elif database_url.startswith("postgres://") or database_url.startswith(
+        "postgresql://"
+    ):
+        if PostgresWorkflowRepository is None:
+            raise RuntimeError("Postgres support not available")
+        _repository_instance = PostgresWorkflowRepository(database_url)
+    else:
+        raise ValueError(f"Unsupported database backend: {database_url}")
+
+    return _repository_instance
+
+
 __all__ = [
     "StepRecord",
     "WorkflowInstance",
     "WorkflowRepository",
     "SQLiteWorkflowRepository",
     "PostgresWorkflowRepository",
+    "InMemoryWorkflowRepository",
+    "get_repository",
 ]

--- a/paigeant/persistence/inmemory.py
+++ b/paigeant/persistence/inmemory.py
@@ -1,0 +1,87 @@
+"""In-memory implementation of the workflow repository."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict
+
+from .models import StepRecord, WorkflowInstance
+from .repository import WorkflowRepository
+
+
+class InMemoryWorkflowRepository(WorkflowRepository):
+    """Store workflow state in local memory.
+
+    Useful for tests or when no database is configured. Data is not
+    persisted across process restarts.
+    """
+
+    def __init__(self) -> None:
+        self._workflows: Dict[str, WorkflowInstance] = {}
+        self._step_id = 0
+
+    # ------------------------------------------------------------------
+    async def create_workflow(
+        self, correlation_id: str, routing_slip: dict, payload: dict | None = None
+    ) -> None:
+        self._workflows[correlation_id] = WorkflowInstance(
+            correlation_id=correlation_id,
+            routing_slip=routing_slip,
+            payload=payload or {},
+            status="in_progress",
+            steps=[],
+        )
+
+    async def update_routing_slip(self, correlation_id: str, routing_slip: dict) -> None:
+        wf = self._workflows.get(correlation_id)
+        if wf:
+            wf.routing_slip = routing_slip
+
+    async def mark_step_started(self, correlation_id: str, step_name: str) -> None:
+        wf = self._workflows.get(correlation_id)
+        if not wf:
+            return
+        self._step_id += 1
+        wf.steps.append(
+            StepRecord(
+                id=self._step_id,
+                correlation_id=correlation_id,
+                step_name=step_name,
+                started_at=datetime.utcnow(),
+            )
+        )
+
+    async def mark_step_completed(
+        self,
+        correlation_id: str,
+        step_name: str,
+        status: str,
+        output: dict | None = None,
+    ) -> None:
+        wf = self._workflows.get(correlation_id)
+        if not wf:
+            return
+        for step in wf.steps:
+            if step.step_name == step_name and step.completed_at is None:
+                step.completed_at = datetime.utcnow()
+                step.status = status
+                step.output = output or {}
+                break
+
+    async def update_payload(self, correlation_id: str, payload: dict) -> None:
+        wf = self._workflows.get(correlation_id)
+        if wf:
+            wf.payload = payload
+
+    async def mark_workflow_completed(
+        self, correlation_id: str, status: str = "completed"
+    ) -> None:
+        wf = self._workflows.get(correlation_id)
+        if wf:
+            wf.status = status
+
+    async def get_workflow(self, correlation_id: str) -> WorkflowInstance | None:
+        return self._workflows.get(correlation_id)
+
+    async def list_workflows(self) -> list[WorkflowInstance]:
+        return list(self._workflows.values())

--- a/paigeant/persistence/postgres.py
+++ b/paigeant/persistence/postgres.py
@@ -172,3 +172,22 @@ class PostgresWorkflowRepository(WorkflowRepository):
             status=row["status"],
             steps=steps,
         )
+
+    async def list_workflows(self) -> list[WorkflowInstance]:
+        conn = await self._connect()
+        try:
+            rows = await conn.fetch(
+                "SELECT correlation_id, routing_slip, payload, status FROM workflows"
+            )
+        finally:
+            await conn.close()
+        return [
+            WorkflowInstance(
+                correlation_id=r["correlation_id"],
+                routing_slip=r["routing_slip"],
+                payload=r["payload"],
+                status=r["status"],
+                steps=[],
+            )
+            for r in rows
+        ]

--- a/paigeant/persistence/repository.py
+++ b/paigeant/persistence/repository.py
@@ -40,3 +40,6 @@ class WorkflowRepository(Protocol):
 
     async def get_workflow(self, correlation_id: str) -> WorkflowInstance | None:
         """Retrieve the workflow instance by id."""
+
+    async def list_workflows(self) -> list[WorkflowInstance]:
+        """Return all persisted workflows."""

--- a/paigeant/persistence/sqlite.py
+++ b/paigeant/persistence/sqlite.py
@@ -170,3 +170,21 @@ class SQLiteWorkflowRepository(WorkflowRepository):
             status=row["status"],
             steps=steps,
         )
+
+    async def list_workflows(self) -> list[WorkflowInstance]:
+        rows = await asyncio.to_thread(
+            self._fetchall,
+            "SELECT correlation_id, routing_slip, payload, status FROM workflows",
+        )
+        workflows: list[WorkflowInstance] = []
+        for row in rows:
+            workflows.append(
+                WorkflowInstance(
+                    correlation_id=row["correlation_id"],
+                    routing_slip=json.loads(row["routing_slip"]),
+                    payload=json.loads(row["payload"]) if row["payload"] else None,
+                    status=row["status"],
+                    steps=[],
+                )
+            )
+        return workflows

--- a/tests/unit/test_persistence_repository.py
+++ b/tests/unit/test_persistence_repository.py
@@ -32,3 +32,6 @@ async def test_sqlite_repository_crud(tmp_path):
     assert step.step_name == "step1"
     assert step.status == "completed"
     assert step.output == {"x": 1}
+
+    all_wfs = await repo.list_workflows()
+    assert any(w.correlation_id == corr_id for w in all_wfs)


### PR DESCRIPTION
## Summary
- load `PAIGEANT_DATABASE_URL` to configure workflow persistence
- add repository factory with in-memory fallback and CLI commands for listing workflows
- document persistence setup and querying examples

## Testing
- `uv run pytest -q` *(fails: ConnectionError connecting to Redis)*
- `uv run pytest tests/unit/test_persistence_repository.py::test_sqlite_repository_crud -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2908a4914832e9069f9830aa9ac27