### PR TITLE
Add persistence repository tests and document experimental support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If an agent crashes, the message stays in the queue until a worker handles it.
 - Optional itinerary editing: agents can insert additional steps
 - Transport abstraction with in-memory and Redis backends
 - Minimal dependencies and `pydantic-ai` integration
+- Experimental persistence via SQLite or PostgreSQL (opt-in)
 
 ## Quick Start
 
@@ -55,8 +56,9 @@ transport = get_transport()  # in-memory by default, configurable via PAIGEANT_T
 correlation_id = await dispatcher.dispatch_workflow(transport)
 ```
 
-To enable state persistence, set a database URL via `PAIGEANT_DATABASE_URL` or
-`DATABASE_URL`. SQLite is supported out of the box:
+To enable experimental state persistence, set a database URL via
+`PAIGEANT_DATABASE_URL` or `DATABASE_URL`. SQLite is supported out of the
+box:
 
 ```bash
 export PAIGEANT_DATABASE_URL=sqlite:///paigeant.db
@@ -86,7 +88,9 @@ uv run pytest -q
 ```
 
 ## Project Status
-Early development. Implemented components: message contracts, workflow dispatcher, activity executor, `PaigeantAgent`, in-memory transport, Redis transport.
+Early development. Implemented components: message contracts, workflow dispatcher,
+activity executor, `PaigeantAgent`, in-memory transport, Redis transport, and an
+experimental persistence layer.
 
 ## License
 MIT

--- a/misc/design/ADR.md
+++ b/misc/design/ADR.md
@@ -34,7 +34,7 @@ Use dependency injection at message reception rather than modifying the routing 
 
 ### Decision
 - Use a workflow repository as a registry to persist routing slips, payloads and step history during integration tests.
-- Enforce uniqueness on `(correlation_id, step_name)` and ignore duplicate `mark_step_started` calls for idempotent step tracking.
+- Enforce uniqueness on `(correlation_id, step_name, run_id)` and ignore duplicate `mark_step_started` calls for the same run to ensure idempotent step tracking while allowing retries.
 
 ### Rationale
 - Guarantees crash recovery and auditing through persisted state.
@@ -42,9 +42,9 @@ Use dependency injection at message reception rather than modifying the routing 
 - Demonstrates repository usage in existing workflows without altering business logic.
 
 ### Implementation
-- Added unique constraint and `INSERT OR IGNORE` semantics to SQLite repository.
+- Added `run_id` column and `INSERT OR IGNORE` semantics to SQLite repository, with matching changes for PostgreSQL.
 - Extended single and multi‑agent integration tests to use `SQLiteWorkflowRepository` and assert persisted workflow state and activity registry availability.
-- Added repository unit test covering duplicate updates.
+- Added repository unit tests covering duplicate updates and multiple step runs.
 
 ### Alternatives Considered
 - Allowing duplicate step inserts and cleaning them later – rejected due to harder querying and audit noise.

--- a/paigeant/__init__.py
+++ b/paigeant/__init__.py
@@ -7,7 +7,7 @@ from .execute import ActivityExecutor
 from .transports import get_transport
 from .persistence import get_repository
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __all__ = [
     "ActivitySpec",
     "ActivityExecutor",

--- a/paigeant/persistence/models.py
+++ b/paigeant/persistence/models.py
@@ -14,6 +14,7 @@ class StepRecord(BaseModel):
     id: Optional[int] = None
     correlation_id: str
     step_name: str
+    run_id: int = 1
     started_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
     status: Optional[str] = None

--- a/paigeant/persistence/repository.py
+++ b/paigeant/persistence/repository.py
@@ -18,8 +18,10 @@ class WorkflowRepository(Protocol):
     async def update_routing_slip(self, correlation_id: str, routing_slip: dict) -> None:
         """Persist updated routing slip."""
 
-    async def mark_step_started(self, correlation_id: str, step_name: str) -> None:
-        """Record start of a step."""
+    async def mark_step_started(
+        self, correlation_id: str, step_name: str, run_id: int = 1
+    ) -> None:
+        """Record start of a step run."""
 
     async def mark_step_completed(
         self,
@@ -27,8 +29,9 @@ class WorkflowRepository(Protocol):
         step_name: str,
         status: str,
         output: dict | None = None,
+        run_id: int = 1,
     ) -> None:
-        """Record completion of a step."""
+        """Record completion of a step run."""
 
     async def update_payload(self, correlation_id: str, payload: dict) -> None:
         """Persist workflow payload updates."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "paigeant"
-version = "0.1.0"
+version = "0.2.0"
 description = "Durable workflow orchestration for AI agents"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/integration/test_persistence_workflow.py
+++ b/tests/integration/test_persistence_workflow.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from paigeant import WorkflowDependencies, WorkflowDispatcher
+from paigeant.agent.wrapper import PaigeantAgent
+from paigeant.execute import ActivityExecutor
+from paigeant.persistence import SQLiteWorkflowRepository
+from paigeant.transports.inmemory import InMemoryTransport
+
+
+class DummyAgent(PaigeantAgent):
+    def __init__(self, dispatcher, name):
+        super().__init__("test", dispatcher=dispatcher, name=name)
+
+    async def run(self, prompt: str, deps: WorkflowDependencies | None = None):
+        return SimpleNamespace(output=f"{self.name}-done")
+
+
+dispatcher = WorkflowDispatcher()
+agent1 = DummyAgent(dispatcher, name="agent1")
+agent2 = DummyAgent(dispatcher, name="agent2")
+
+
+@pytest.mark.asyncio
+async def test_workflow_persistence_restart_and_idempotency(tmp_path):
+    transport = InMemoryTransport()
+    repo_path = tmp_path / "wf.db"
+    repo = SQLiteWorkflowRepository(repo_path)
+
+    deps = WorkflowDependencies()
+    agent1.add_to_runway(prompt="step1", deps=deps)
+    agent2.add_to_runway(prompt="step2", deps=deps)
+
+    corr_id = await dispatcher.dispatch_workflow(transport, repository=repo)
+
+    raw = transport._queues["agent1"].popleft()
+    msg = raw[1]
+    dup = msg.model_copy(deep=True)
+    transport._queues["agent1"].append((dup.to_json(), dup))
+
+    executor1 = ActivityExecutor(transport, agent_name="agent1", repository=repo, base_path=Path(__file__))
+    await executor1._handle_activity(executor1.extract_activity(msg), msg)
+    raw_dup = transport._queues["agent1"].popleft()
+    msg_dup = raw_dup[1]
+    await executor1._handle_activity(executor1.extract_activity(msg_dup), msg_dup)
+
+    repo = SQLiteWorkflowRepository(repo_path)
+    executor2 = ActivityExecutor(transport, agent_name="agent2", repository=repo, base_path=Path(__file__))
+    while transport._queues["agent2"]:
+        raw2 = transport._queues["agent2"].popleft()
+        msg2 = raw2[1]
+        await executor2._handle_activity(executor2.extract_activity(msg2), msg2)
+
+    wf = await repo.get_workflow(corr_id)
+    assert wf is not None
+    assert wf.status == "completed"
+    assert {s.step_name for s in wf.steps} == {"agent1", "agent2"}


### PR DESCRIPTION
## Summary
- allow multiple step executions by tracking a run_id in persisted step history
- enforce `(correlation_id, step_name, run_id)` uniqueness across SQLite, PostgreSQL and in-memory repositories
- expand persistence tests to verify idempotency per run and document design change

## Testing
- `pytest tests/unit/test_persistence_repository.py tests/unit/test_postgres_repository.py tests/integration/test_persistence_workflow.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b29da4a568832e95d864753a607299