### PR TITLE
feat: scaffold zero-trust security package

### DIFF
--- a/paigeant/security/__init__.py
+++ b/paigeant/security/__init__.py
@@ -1,0 +1,2 @@
+"""Security components for Paigeant's zero-trust architecture."""
+

--- a/paigeant/security/audit.py
+++ b/paigeant/security/audit.py
@@ -1,0 +1,13 @@
+"""Audit logging utilities for security events."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class AuditLog:
+    """Records signatures and authorization decisions."""
+
+    async def record(self, event: str, details: Any) -> None:  # pragma: no cover - outline
+        """Persist an audit log entry."""
+        raise NotImplementedError

--- a/paigeant/security/context.py
+++ b/paigeant/security/context.py
@@ -1,0 +1,42 @@
+"""Security context and related models for Paigeant."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class SecurityContext(BaseModel):
+    """Carries authentication and authorization state for a message flow.
+
+    The context travels alongside a :class:`~paigeant.contracts.PaigeantMessage`
+    and is evaluated at each hop in the system.  Implementations are expected
+    to populate the context with the on‑behalf‑of token, derived claims and
+    any session or delegation metadata required for policy enforcement.
+    """
+
+    obo_token: Optional[str] = Field(default=None, description="Delegation token")
+    claims: Dict[str, Any] = Field(default_factory=dict, description="Token claims")
+
+
+class CanonicalMessage(BaseModel):
+    """Canonical representation of a message used for signing."""
+
+    payload: Dict[str, Any] = Field(default_factory=dict)
+    headers: Dict[str, Any] = Field(default_factory=dict)
+
+
+class JwsSignatureRecord(BaseModel):
+    """Record of a JWS signature including headers and key id."""
+
+    kid: str = Field(..., description="Key identifier used for signing")
+    algorithm: str = Field(..., description="JWS algorithm")
+    signature: str = Field(..., description="Detached JWS signature")
+
+
+class SignatureEnvelope(BaseModel):
+    """Envelope tying a canonical message to its signature record."""
+
+    message: CanonicalMessage
+    signature: JwsSignatureRecord

--- a/paigeant/security/jws.py
+++ b/paigeant/security/jws.py
@@ -1,0 +1,28 @@
+"""JWS signing and verification services."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .context import CanonicalMessage, SignatureEnvelope
+
+
+class JwsService:
+    """Signs and verifies messages using JSON Web Signatures.
+
+    The service operates on canonical message representations to ensure
+    deterministic signatures.  Signatures are produced in detached payload
+    form (RFC 7797) and are expected to use modern algorithms such as ES256
+    or EdDSA.
+    """
+
+    def __init__(self, key_provider: Any) -> None:
+        self.key_provider = key_provider
+
+    async def sign(self, message: CanonicalMessage) -> SignatureEnvelope:  # pragma: no cover - outline
+        """Sign ``message`` and return the signature envelope."""
+        raise NotImplementedError
+
+    async def verify(self, envelope: SignatureEnvelope) -> bool:  # pragma: no cover
+        """Verify the signature for the given ``envelope``."""
+        raise NotImplementedError

--- a/paigeant/security/keys.py
+++ b/paigeant/security/keys.py
@@ -1,0 +1,17 @@
+"""Key management utilities for signing and verification."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class KeyProvider:
+    """Provides signing and verification keys with rotation support."""
+
+    async def get_signing_key(self) -> Any:  # pragma: no cover - outline
+        """Return the current private key used for signing."""
+        raise NotImplementedError
+
+    async def get_verification_keys(self) -> dict[str, Any]:  # pragma: no cover
+        """Return mapping of ``kid`` to public keys for verification."""
+        raise NotImplementedError

--- a/paigeant/security/middleware.py
+++ b/paigeant/security/middleware.py
@@ -1,0 +1,27 @@
+"""Middleware helpers for applying security checks."""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable
+
+from .context import SecurityContext
+
+
+Handler = Callable[[Any], Awaitable[Any]]
+
+
+def with_security(handler: Handler) -> Handler:
+    """Wrap ``handler`` with token validation and policy enforcement.
+
+    This is a placeholder demonstrating where security hooks would execute.
+    The middleware would typically construct a :class:`SecurityContext`, validate
+    incoming tokens, verify message signatures and consult the
+    :class:`~paigeant.security.policy.PolicyEngine` before invoking ``handler``.
+    """
+
+    async def _wrapper(message: Any) -> Any:  # pragma: no cover - outline
+        context = SecurityContext()
+        _ = context  # placeholder to avoid linter errors
+        return await handler(message)
+
+    return _wrapper

--- a/paigeant/security/policy.py
+++ b/paigeant/security/policy.py
@@ -1,0 +1,13 @@
+"""Runtime policy enforcement for Paigeant."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class PolicyEngine:
+    """Evaluates authorization policies at runtime."""
+
+    async def evaluate(self, context: Any, action: str, resource: str) -> bool:  # pragma: no cover
+        """Return ``True`` if the ``action`` on ``resource`` is permitted."""
+        raise NotImplementedError

--- a/paigeant/security/tokens.py
+++ b/paigeant/security/tokens.py
@@ -1,0 +1,26 @@
+"""Utilities for validating and exchanging security tokens."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class TokenValidator:
+    """Validates sender-constrained and audience-bound tokens.
+
+    Concrete implementations should retrieve signing keys via JWKS and perform
+    all necessary validation steps such as expiration, issuer, audience and
+    mTLS/DPoP binding checks.
+    """
+
+    async def validate(self, token: str) -> Dict[str, Any]:  # pragma: no cover - outline
+        """Validate ``token`` and return its claims."""
+        raise NotImplementedError
+
+
+class TokenExchanger:
+    """Exchanges tokens to enforce least-privilege delegation per hop."""
+
+    async def exchange(self, token: str, audience: str) -> str:  # pragma: no cover
+        """Produce a new token scoped to ``audience`` for OBO delegation."""
+        raise NotImplementedError

--- a/paigeant/security/transport.py
+++ b/paigeant/security/transport.py
@@ -1,0 +1,13 @@
+"""Transport-level security configuration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class TransportSecurity:
+    """Configures TLS, mTLS or SASL settings for transports."""
+
+    async def configure(self, transport: Any) -> None:  # pragma: no cover - outline
+        """Apply security configuration to ``transport``."""
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- add `security` package with context, token, key, JWS, policy, middleware, transport, and audit scaffolds
- outline Pydantic models for signed messages and security context

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mistralai_azure')*


------
https://chatgpt.com/codex/tasks/task_e_68b5468e2ca4832e9faac16b5a0abf14