### PR TITLE
Register agents in shared registry

### DIFF
--- a/paigeant/__init__.py
+++ b/paigeant/__init__.py
@@ -6,6 +6,7 @@ from .dispatch import WorkflowDispatcher
 from .execute import ActivityExecutor
 from .transports import get_transport
 from .persistence import get_repository
+from .registry import REGISTRY
 
 __version__ = "0.2.0"
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "get_repository",
     "PaigeantAgent",
     "WorkflowDependencies",
+    "REGISTRY",
 ]

--- a/paigeant/agent/wrapper.py
+++ b/paigeant/agent/wrapper.py
@@ -11,6 +11,7 @@ from paigeant.contracts import ActivitySpec, WorkflowDependencies
 
 from ..constants import DEFAULT_ITINERARY_EDIT_LIMIT
 from ..dispatch import WorkflowDispatcher
+from ..registry import AgentDescriptor, SemanticVersion, register_agent
 from ..tools import _edit_itinerary, _extract_previous_output, _itinerary_editing_prompt
 
 logger = logging.getLogger(__name__)
@@ -71,6 +72,14 @@ class PaigeantAgent(Agent):
         self.dispatcher._agent_registry[self.agent_id] = {}
         if getattr(self, "name", None):
             AGENT_REGISTRY[self.name] = self
+            # Record this agent in the global registry for discovery purposes.
+            descriptor = AgentDescriptor(
+                name=self.name,
+                version=SemanticVersion(major=0, minor=0, patch=0),
+                transport="internal",
+                address=self.name,
+            )
+            register_agent(descriptor)
 
     def add_to_runway(
         self,

--- a/paigeant/registry/__init__.py
+++ b/paigeant/registry/__init__.py
@@ -1,12 +1,36 @@
 """Registry data models and utilities."""
 
+from __future__ import annotations
+
 from .models import (
-    SemanticVersion,
-    ParamDescriptor,
     AgentDescriptor,
     Group,
+    ParamDescriptor,
     RegistryRoot,
+    SemanticVersion,
 )
+
+# In-memory representation of the agent registry.  This is intentionally
+# lightweight – for now it simply keeps track of descriptors that are added at
+# runtime.  Future implementations may persist this structure or expose it via
+# an API, but keeping the canonical location here makes it easy for agents to
+# register themselves.
+REGISTRY = RegistryRoot()
+
+
+def register_agent(descriptor: AgentDescriptor, group: str = "default") -> None:
+    """Add ``descriptor`` to ``REGISTRY`` under ``group``.
+
+    Groups are created on-demand.  Duplicate agent names within the same group
+    are not checked for; callers should ensure uniqueness if desired.
+    """
+
+    group_obj = next((g for g in REGISTRY.groups if g.name == group), None)
+    if group_obj is None:
+        group_obj = Group(name=group)
+        REGISTRY.groups.append(group_obj)
+    group_obj.agents.append(descriptor)
+
 
 __all__ = [
     "SemanticVersion",
@@ -14,4 +38,6 @@ __all__ = [
     "AgentDescriptor",
     "Group",
     "RegistryRoot",
+    "REGISTRY",
+    "register_agent",
 ]

--- a/tests/integration/test_registry_agent.py
+++ b/tests/integration/test_registry_agent.py
@@ -1,0 +1,32 @@
+import os
+
+from paigeant import PaigeantAgent, WorkflowDependencies, WorkflowDispatcher, REGISTRY
+
+
+class DummyDeps(WorkflowDependencies):
+    """Simple dependencies class for testing."""
+    pass
+
+
+def test_agent_added_to_registry():
+    """Creating a PaigeantAgent should register it in the global registry."""
+    # Ensure registry is clean
+    REGISTRY.groups.clear()
+
+    os.environ.setdefault("ANTHROPIC_API_KEY", "test")
+    dispatcher = WorkflowDispatcher()
+    agent_name = "registry_test_agent"
+
+    PaigeantAgent(
+        "anthropic:claude-3-5-sonnet-latest",
+        dispatcher=dispatcher,
+        name=agent_name,
+        deps_type=DummyDeps,
+    )
+
+    assert any(
+        descriptor.name == agent_name
+        for group in REGISTRY.groups
+        for descriptor in group.agents
+    )
+


### PR DESCRIPTION
## Summary
- add in-memory agent registry with helper to register agents
- hook PaigeantAgent to record itself in the registry when instantiated
- expose registry and test that agents are registered

## Testing
- `pytest tests/integration/test_registry_agent.py -q`
- `pytest -q` *(fails: Connection error to Anthropic API in multi-agent and single-agent integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b549ee5aec832eb77d564fb374a8b8