### PR TITLE
Refine agent discovery to follow imported re-exports

### DIFF
--- a/paigeant/agent/discovery.py
+++ b/paigeant/agent/discovery.py
@@ -2,17 +2,187 @@
 
 from __future__ import annotations
 
+import ast
 import pkgutil
 import sys
+from dataclasses import dataclass
 from importlib import import_module
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 from pydantic_ai import Agent
 
 from paigeant.cli_utils.fs import _iter_python_files
-from paigeant.discovery import discover_agents_in_module
+from paigeant.discovery.agents import AgentModuleInspector, ImportedSymbol
+from paigeant.discovery.entities import AgentDefinition
+
+
+@dataclass(frozen=True)
+class _ModuleReport:
+    """Summary of agent-related metadata discovered in a module."""
+
+    path: Path
+    module: Optional[str]
+    package: Optional[str]
+    is_package: bool
+    definitions: tuple[AgentDefinition, ...]
+    export_names: frozenset[str]
+    imports: tuple[ImportedSymbol, ...]
+
+
+def _module_name_from_path(
+    search_root: Path, module_root: Path, file_path: Path
+) -> tuple[Optional[str], bool]:
+    """Return dotted module path and package flag for ``file_path``."""
+
+    if search_root.is_file():
+        if file_path == search_root:
+            return search_root.stem, False
+        return None, False
+
+    try:
+        relative = file_path.relative_to(module_root)
+    except ValueError:
+        return None, False
+
+    parts = list(relative.parts)
+    if not parts:
+        return None, False
+
+    is_package = parts[-1] == "__init__.py"
+    if is_package:
+        parts = parts[:-1]
+    else:
+        leaf = parts[-1]
+        parts[-1] = leaf[:-3] if leaf.endswith(".py") else leaf
+
+    prefix: list[str] = []
+    root_init = module_root / "__init__.py"
+    if module_root.is_dir() and root_init.exists():
+        prefix.append(module_root.name)
+
+    module_parts = prefix + parts if parts else prefix
+    module_name = ".".join(module_parts) if module_parts else None
+    return module_name, is_package
+
+
+def _package_name_for_module(
+    module_name: Optional[str], is_package: bool
+) -> Optional[str]:
+    if module_name is None:
+        return None
+    if is_package:
+        return module_name
+    if "." in module_name:
+        return module_name.rsplit(".", 1)[0]
+    return None
+
+
+def _resolve_imported_module(
+    package: Optional[str], symbol: ImportedSymbol
+) -> Optional[str]:
+    level = symbol.level or 0
+    target = symbol.module or ""
+    if level == 0:
+        return target or None
+    if not package:
+        return None
+
+    dot = len(package)
+    for _ in range(level, 1, -1):
+        try:
+            dot = package.rindex(".", 0, dot)
+        except ValueError:
+            return None
+
+    prefix = package[:dot]
+    if target:
+        if prefix:
+            return f"{prefix}.{target}"
+        return target
+    return prefix or None
+
+
+def _lookup_definition(
+    symbol_map: Dict[str, Dict[str, AgentDefinition]],
+    module_name: Optional[str],
+    symbol: ImportedSymbol,
+) -> Optional[AgentDefinition]:
+    if not module_name:
+        return None
+    exports = symbol_map.get(module_name)
+    if not exports:
+        return None
+    symbol_key = symbol.name.split(".")[-1]
+    return exports.get(symbol_key)
+
+
+def _build_symbol_index(reports: list[_ModuleReport]) -> Dict[str, Dict[str, AgentDefinition]]:
+    symbol_map: Dict[str, Dict[str, AgentDefinition]] = {}
+    reports_by_module: Dict[str, _ModuleReport] = {
+        report.module: report
+        for report in reports
+        if report.module
+    }
+
+    for report in reports:
+        if not report.module:
+            continue
+        module_exports = symbol_map.setdefault(report.module, {})
+        for definition in report.definitions:
+            for export in definition.exports:
+                module_exports.setdefault(export, definition)
+
+    changed = True
+    while changed:
+        changed = False
+        for module_name, report in reports_by_module.items():
+            module_exports = symbol_map.setdefault(module_name, {})
+            export_names = report.export_names
+            for symbol in report.imports:
+                alias = symbol.alias
+                if not alias:
+                    continue
+                if export_names and alias not in export_names:
+                    continue
+                target_module = _resolve_imported_module(report.package, symbol)
+                if not target_module:
+                    continue
+                definition = _lookup_definition(symbol_map, target_module, symbol)
+                if not definition:
+                    continue
+                if alias not in module_exports:
+                    module_exports[alias] = definition
+                    changed = True
+
+    return symbol_map
+
+
+def _analyze_module(
+    py_file: Path, search_root: Path, module_root: Path
+) -> Optional[_ModuleReport]:
+    module_name, is_package = _module_name_from_path(search_root, module_root, py_file)
+    try:
+        source = py_file.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(py_file))
+    except (OSError, UnicodeDecodeError, SyntaxError):
+        return None
+
+    inspector = AgentModuleInspector(path=py_file, module=module_name)
+    inspector.visit(tree)
+    definitions = inspector.build_definitions()
+    package_name = _package_name_for_module(module_name, is_package)
+
+    return _ModuleReport(
+        path=py_file,
+        module=module_name,
+        package=package_name,
+        is_package=is_package,
+        definitions=definitions,
+        export_names=frozenset(inspector.export_names),
+        imports=inspector.imported_symbols,
+    )
 
 
 def find_agent_in_file(agent_name: str, base_path: Path) -> Agent:
@@ -101,25 +271,54 @@ def discover_agents_in_path(
     if not resolved_path.exists():
         raise FileNotFoundError(f"Search path does not exist: {resolved_path}")
 
+    module_root = resolved_path if resolved_path.is_dir() else resolved_path.parent
+
+    reports: list[_ModuleReport] = []
+    for py_file in _iter_python_files(resolved_path, respect_gitignore):
+        report = _analyze_module(py_file, resolved_path, module_root)
+        if report is None:
+            continue
+        reports.append(report)
+
+    symbol_index = _build_symbol_index(reports)
+
     discoveries: list[dict[str, object]] = []
     seen: set[tuple[str, Path]] = set()
 
-    for py_file in _iter_python_files(resolved_path, respect_gitignore):
-        try:
-            definitions = discover_agents_in_module(py_file)
-        except (OSError, SyntaxError):
-            continue
-
-        for definition in definitions:
+    for report in reports:
+        for definition in report.definitions:
             candidates = [definition.name, *definition.exports]
             for agent_name in candidates:
                 if not agent_name:
                     continue
-                key = (agent_name, py_file)
+                key = (agent_name, report.path)
                 if key in seen:
                     continue
-                discoveries.append({"name": agent_name, "path": py_file})
+                discoveries.append({"name": agent_name, "path": report.path})
                 seen.add(key)
+
+    for report in reports:
+        module_name = report.module
+        if not module_name:
+            continue
+        exported = symbol_index.get(module_name, {})
+        if not exported:
+            continue
+
+        direct_names = {
+            export_name
+            for definition in report.definitions
+            for export_name in definition.exports
+        }
+
+        for alias in exported:
+            if alias in direct_names:
+                continue
+            key = (alias, report.path)
+            if key in seen:
+                continue
+            discoveries.append({"name": alias, "path": report.path})
+            seen.add(key)
 
     discoveries.sort(key=lambda item: (str(item["path"]), item["name"]))
 

--- a/paigeant/agent/discovery.py
+++ b/paigeant/agent/discovery.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import pkgutil
 import sys
-from dataclasses import dataclass
 from importlib import import_module
-from importlib.util import module_from_spec, spec_from_file_location
+from importlib.util import find_spec, module_from_spec, spec_from_file_location
 from pathlib import Path
 from typing import Dict, Optional
 
+from pydantic import BaseModel, ConfigDict
 from pydantic_ai import Agent
 
 from paigeant.cli_utils.fs import _iter_python_files
@@ -17,8 +17,7 @@ from paigeant.discovery.agents import ImportedSymbol, inspect_agents_in_module
 from paigeant.discovery.entities import AgentDefinition
 
 
-@dataclass(frozen=True)
-class _ModuleReport:
+class _ModuleReport(BaseModel):
     """Summary of agent-related metadata discovered in a module."""
 
     path: Path
@@ -29,20 +28,19 @@ class _ModuleReport:
     export_names: frozenset[str]
     imports: tuple[ImportedSymbol, ...]
 
+    model_config = ConfigDict(frozen=True)
+
 
 def _module_name_from_path(
     search_root: Path, module_root: Path, file_path: Path
 ) -> tuple[Optional[str], bool]:
     """Return dotted module path and package flag for ``file_path``."""
 
-    if search_root.is_file():
-        if file_path == search_root:
-            return search_root.stem, False
-        return None, False
-
     try:
         relative = file_path.relative_to(module_root)
     except ValueError:
+        if search_root.is_file() and file_path == search_root:
+            return search_root.stem, False
         return None, False
 
     parts = list(relative.parts)
@@ -117,12 +115,12 @@ def _lookup_definition(
     return exports.get(symbol_key)
 
 
-def _build_symbol_index(reports: list[_ModuleReport]) -> Dict[str, Dict[str, AgentDefinition]]:
+def _build_symbol_index(
+    reports: list[_ModuleReport],
+) -> Dict[str, Dict[str, AgentDefinition]]:
     symbol_map: Dict[str, Dict[str, AgentDefinition]] = {}
     reports_by_module: Dict[str, _ModuleReport] = {
-        report.module: report
-        for report in reports
-        if report.module
+        report.module: report for report in reports if report.module
     }
 
     for report in reports:
@@ -158,19 +156,18 @@ def _build_symbol_index(reports: list[_ModuleReport]) -> Dict[str, Dict[str, Age
     return symbol_map
 
 
-def _analyze_module(
-    py_file: Path, search_root: Path, module_root: Path
+def _create_report(
+    path: Path, module_name: Optional[str], is_package: bool
 ) -> Optional[_ModuleReport]:
-    module_name, is_package = _module_name_from_path(search_root, module_root, py_file)
     try:
-        report = inspect_agents_in_module(py_file, module=module_name)
+        report = inspect_agents_in_module(path, module=module_name)
     except (OSError, UnicodeDecodeError, SyntaxError):
         return None
 
     package_name = _package_name_for_module(module_name, is_package)
 
     return _ModuleReport(
-        path=py_file,
+        path=path,
         module=module_name,
         package=package_name,
         is_package=is_package,
@@ -178,6 +175,125 @@ def _analyze_module(
         export_names=frozenset(report.export_names),
         imports=report.imported_symbols,
     )
+
+
+def _analyze_module(
+    py_file: Path, search_root: Path, module_root: Path
+) -> Optional[_ModuleReport]:
+    module_name, is_package = _module_name_from_path(search_root, module_root, py_file)
+    return _create_report(py_file, module_name, is_package)
+
+
+def _candidate_roots(search_root: Path, module_root: Path) -> tuple[Path, ...]:
+    roots: list[Path] = []
+
+    def _add(path: Optional[Path]) -> None:
+        if path is None:
+            return
+        try:
+            resolved = path.resolve()
+        except OSError:
+            return
+        if not resolved.exists():
+            return
+        directory = resolved if resolved.is_dir() else resolved.parent
+        if directory == directory.parent:
+            return
+        if directory not in roots:
+            roots.append(directory)
+
+    _add(Path.cwd())
+    _add(module_root)
+    _add(module_root.parent)
+    if search_root.is_file():
+        _add(search_root.parent)
+    else:
+        _add(search_root)
+
+    return tuple(roots)
+
+
+def _within_allowed_roots(path: Path, roots: tuple[Path, ...]) -> bool:
+    for root in roots:
+        try:
+            path.resolve().relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _resolve_module_origin(
+    module_name: str, allowed_roots: tuple[Path, ...]
+) -> tuple[Optional[Path], bool]:
+    try:
+        spec = find_spec(module_name)
+    except (ImportError, ValueError):
+        spec = None
+
+    if spec and spec.origin not in {None, "namespace", "built-in"}:
+        origin_path = Path(spec.origin)
+        if origin_path.suffix == ".py" and origin_path.exists():
+            if not allowed_roots or _within_allowed_roots(origin_path, allowed_roots):
+                return origin_path, bool(spec.submodule_search_locations)
+
+    module_parts = Path(*module_name.split("."))
+    search_roots = allowed_roots or (Path.cwd(),)
+    for root in search_roots:
+        try:
+            resolved_root = root.resolve()
+        except OSError:
+            continue
+
+        candidate_file = (resolved_root / module_parts).with_suffix(".py")
+        if candidate_file.exists():
+            return candidate_file, False
+
+        candidate_init = resolved_root / module_parts / "__init__.py"
+        if candidate_init.exists():
+            return candidate_init, True
+
+    return None, False
+
+
+def _analyze_imported_module(
+    module_name: str, allowed_roots: tuple[Path, ...]
+) -> Optional[_ModuleReport]:
+    origin_path, is_package = _resolve_module_origin(module_name, allowed_roots)
+    if origin_path is None:
+        return None
+    return _create_report(origin_path, module_name, is_package)
+
+
+def _extend_reports_with_imports(
+    reports: list[_ModuleReport], search_root: Path, module_root: Path
+) -> None:
+    if not reports:
+        return
+
+    allowed_roots = _candidate_roots(search_root, module_root)
+
+    known_modules: dict[str, _ModuleReport] = {
+        report.module: report for report in reports if report.module
+    }
+
+    visited = set(known_modules)
+    queue: list[_ModuleReport] = [report for report in reports if report.module]
+
+    while queue:
+        report = queue.pop()
+        for symbol in report.imports:
+            target_module = _resolve_imported_module(report.package, symbol)
+            if not target_module or target_module in visited:
+                continue
+            visited.add(target_module)
+            extra_report = _analyze_imported_module(target_module, allowed_roots)
+            if extra_report is None:
+                continue
+            reports.append(extra_report)
+            if extra_report.module and extra_report.module not in known_modules:
+                known_modules[extra_report.module] = extra_report
+                queue.append(extra_report)
 
 
 def find_agent_in_file(agent_name: str, base_path: Path) -> Agent:
@@ -274,6 +390,8 @@ def discover_agents_in_path(
         if report is None:
             continue
         reports.append(report)
+
+    _extend_reports_with_imports(reports, resolved_path, module_root)
 
     symbol_index = _build_symbol_index(reports)
 

--- a/paigeant/discovery/__init__.py
+++ b/paigeant/discovery/__init__.py
@@ -1,6 +1,12 @@
 """Discovery domain models and helpers."""
 
-from .agents import AgentModuleInspector, ImportedSymbol, discover_agents_in_module
+from .agents import (
+    AgentModuleInspector,
+    ImportedSymbol,
+    ModuleAgentReport,
+    discover_agents_in_module,
+    inspect_agents_in_module,
+)
 from .entities import (
     AgentDefinition,
     DependencyDefinition,
@@ -15,7 +21,9 @@ from .workflows import WorkflowModuleInspector, discover_workflow_in_module
 __all__ = [
     "AgentModuleInspector",
     "ImportedSymbol",
+    "ModuleAgentReport",
     "discover_agents_in_module",
+    "inspect_agents_in_module",
     "AgentDefinition",
     "DependencyDefinition",
     "DiscoverySource",

--- a/paigeant/discovery/__init__.py
+++ b/paigeant/discovery/__init__.py
@@ -1,6 +1,6 @@
 """Discovery domain models and helpers."""
 
-from .agents import AgentModuleInspector, discover_agents_in_module
+from .agents import AgentModuleInspector, ImportedSymbol, discover_agents_in_module
 from .entities import (
     AgentDefinition,
     DependencyDefinition,
@@ -14,6 +14,7 @@ from .workflows import WorkflowModuleInspector, discover_workflow_in_module
 
 __all__ = [
     "AgentModuleInspector",
+    "ImportedSymbol",
     "discover_agents_in_module",
     "AgentDefinition",
     "DependencyDefinition",

--- a/paigeant/discovery/agents.py
+++ b/paigeant/discovery/agents.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import ast
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable, Optional
 
@@ -37,8 +36,7 @@ class ImportedSymbol(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
-@dataclass(frozen=True)
-class ModuleAgentReport:
+class ModuleAgentReport(BaseModel):
     """Summary of Paigeant agent analysis for a module."""
 
     path: Path
@@ -46,6 +44,8 @@ class ModuleAgentReport:
     definitions: tuple[AgentDefinition, ...]
     export_names: tuple[str, ...]
     imported_symbols: tuple[ImportedSymbol, ...]
+
+    model_config = ConfigDict(frozen=True)
 
 
 class AgentModuleInspector(BaseInspector):

--- a/paigeant/discovery/agents.py
+++ b/paigeant/discovery/agents.py
@@ -24,6 +24,18 @@ class _AgentCandidate(BaseModel):
     model_config = ConfigDict(frozen=True)
 
 
+class ImportedSymbol(BaseModel):
+    """Representation of a symbol imported into a module."""
+
+    module: Optional[str] = None
+    name: str
+    alias: str
+    level: int = 0
+    span: Optional[SourceSpan] = None
+
+    model_config = ConfigDict(frozen=True)
+
+
 class AgentModuleInspector(BaseInspector):
     """Collect Paigeant agent definitions from a Python module."""
 
@@ -38,6 +50,7 @@ class AgentModuleInspector(BaseInspector):
         )
         self._candidates: list[_AgentCandidate] = []
         self._export_names: set[str] = set()
+        self._imported_symbols: list[ImportedSymbol] = []
 
     # ------------------------------------------------------------------
     # Assignment handling
@@ -51,6 +64,22 @@ class AgentModuleInspector(BaseInspector):
         if self._handle_assignment(node.value, (node.target,)):
             return
         self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:  # pragma: no cover - AST
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            alias_name = alias.asname or alias.name.split(".")[-1]
+            self._imported_symbols.append(
+                ImportedSymbol(
+                    module=node.module,
+                    name=alias.name,
+                    alias=alias_name,
+                    level=node.level or 0,
+                    span=node_span(node),
+                )
+            )
+        super().visit_ImportFrom(node)
 
     # ------------------------------------------------------------------
     # Helpers
@@ -171,6 +200,17 @@ class AgentModuleInspector(BaseInspector):
                 return tuple(exports)
         return tuple(name for name in assigned if name)
 
+    # ------------------------------------------------------------------
+    # Metadata accessors
+    # ------------------------------------------------------------------
+    @property
+    def export_names(self) -> tuple[str, ...]:
+        return tuple(self._export_names)
+
+    @property
+    def imported_symbols(self) -> tuple[ImportedSymbol, ...]:
+        return tuple(self._imported_symbols)
+
 
 def discover_agents_in_module(
     path: Path, *, module: Optional[str] = None
@@ -184,4 +224,4 @@ def discover_agents_in_module(
     return inspector.build_definitions()
 
 
-__all__ = ["AgentModuleInspector", "discover_agents_in_module"]
+__all__ = ["AgentModuleInspector", "discover_agents_in_module", "ImportedSymbol"]

--- a/tests/unit/test_agent_discovery_path.py
+++ b/tests/unit/test_agent_discovery_path.py
@@ -53,3 +53,58 @@ __all__ = ["primary_agent"]
     assert ("primary_agent", primary_path) in results
     assert ("primary_agent", sub_init_path) in results
     assert ("primary_agent", pkg_init_path) in results
+
+
+def test_discover_agents_in_path_includes_imported_agents_from_file(
+    tmp_path: Path,
+) -> None:
+    pkg_dir = tmp_path / "pkg"
+    pkg_dir.mkdir(parents=True)
+
+    primary_source = """
+from paigeant import PaigeantAgent, WorkflowDispatcher
+
+dispatcher = WorkflowDispatcher()
+
+primary_agent = PaigeantAgent(
+    "model",
+    dispatcher=dispatcher,
+    name="primary_agent",
+)
+"""
+
+    consumer_source = """
+from paigeant import PaigeantAgent, WorkflowDispatcher
+from pkg.primary import primary_agent
+
+dispatcher = WorkflowDispatcher()
+
+secondary_agent = PaigeantAgent(
+    "model",
+    dispatcher=dispatcher,
+    name="secondary",
+)
+"""
+
+    pkg_init = pkg_dir / "__init__.py"
+    pkg_init.write_text("", encoding="utf-8")
+
+    primary_path = pkg_dir / "primary.py"
+    primary_path.write_text(primary_source, encoding="utf-8")
+
+    consumer_path = pkg_dir / "consumer.py"
+    consumer_path.write_text(consumer_source, encoding="utf-8")
+
+    import sys
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        discoveries = discover_agents_in_path(consumer_path)
+    finally:
+        sys.path.remove(str(tmp_path))
+
+    results = {(item["name"], item["path"]) for item in discoveries}
+
+    assert ("secondary", consumer_path) in results
+    assert ("primary_agent", consumer_path) in results
+    assert ("primary_agent", primary_path) in results

--- a/tests/unit/test_agent_discovery_path.py
+++ b/tests/unit/test_agent_discovery_path.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from paigeant.agent.discovery import discover_agents_in_path
+
+
+def test_discover_agents_in_path_handles_reexports(tmp_path: Path) -> None:
+    pkg_dir = tmp_path / "pkg"
+    sub_dir = pkg_dir / "sub"
+    sub_dir.mkdir(parents=True)
+
+    primary_source = """
+from paigeant import PaigeantAgent, WorkflowDispatcher
+
+dispatcher = WorkflowDispatcher()
+
+__all__ = ["primary_agent"]
+
+primary_agent = PaigeantAgent(
+    "model",
+    dispatcher=dispatcher,
+    name="primary",
+)
+"""
+
+    sub_init_source = """
+from ..primary import primary_agent
+
+__all__ = ["primary_agent"]
+"""
+
+    pkg_init_source = """
+from .sub import primary_agent
+
+__all__ = ["primary_agent"]
+"""
+
+    primary_path = pkg_dir / "primary.py"
+    primary_path.write_text(primary_source, encoding="utf-8")
+
+    sub_init_path = sub_dir / "__init__.py"
+    sub_init_path.write_text(sub_init_source, encoding="utf-8")
+
+    pkg_init_path = pkg_dir / "__init__.py"
+    pkg_init_path.write_text(pkg_init_source, encoding="utf-8")
+
+    discoveries = discover_agents_in_path(pkg_dir)
+
+    results = {(item["name"], item["path"]) for item in discoveries}
+
+    assert ("primary", primary_path) in results
+    assert ("primary_agent", primary_path) in results
+    assert ("primary_agent", sub_init_path) in results
+    assert ("primary_agent", pkg_init_path) in results


### PR DESCRIPTION
## Summary
- capture imported symbols alongside PaigeantAgent definitions during module inspection
- rework agent path discovery to resolve module names, follow relative imports, and surface re-exported agent bindings
- cover import-based discovery with a unit test exercising chained package re-exports

## Testing
- PYTHONPATH=. pytest tests/unit/test_agent_discovery_path.py *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68f497b27c40832e83dbe30cb614bb09